### PR TITLE
Fix asset references in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,13 +20,13 @@
     },
     "web": {
       "bundler": "metro",
-      "favicon": "./assets/images/favicon.png"
+      "favicon": "./assets/images/icon.png"
     },
     "plugins": [
       [
         "expo-splash-screen",
         {
-          "image": "./assets/images/splash-icon.png",
+          "image": "./assets/images/icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"


### PR DESCRIPTION
## Summary
- reference existing icon files for favicon and splash screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845eca6c54c832a8092c8a6a1b4dd39