### PR TITLE
Add missing theme hooks and constants

### DIFF
--- a/src/constants/Colors.ts
+++ b/src/constants/Colors.ts
@@ -1,0 +1,12 @@
+export const Colors = {
+  light: {
+    text: '#000',
+    background: '#fff',
+    icon: '#0a7ea4',
+  },
+  dark: {
+    text: '#fff',
+    background: '#000',
+    icon: '#f9fafb',
+  },
+};

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -1,0 +1,8 @@
+import { ColorSchemeName, useColorScheme as useNativeColorScheme } from 'react-native';
+
+/**
+ * A wrapper around React Native's `useColorScheme` that always returns a non-null value.
+ */
+export function useColorScheme(): NonNullable<ColorSchemeName> {
+  return (useNativeColorScheme() ?? 'light') as NonNullable<ColorSchemeName>;
+}

--- a/src/hooks/useThemeColor.ts
+++ b/src/hooks/useThemeColor.ts
@@ -1,0 +1,16 @@
+import { Colors } from '../constants/Colors';
+import { useColorScheme } from './useColorScheme';
+
+export function useThemeColor(
+  props: { light?: string; dark?: string },
+  colorName: keyof typeof Colors.light
+) {
+  const theme = useColorScheme();
+  const colorFromProps = theme === 'light' ? props.light : props.dark;
+
+  if (colorFromProps) {
+    return colorFromProps;
+  }
+
+  return Colors[theme][colorName];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add Colors constant
- implement useColorScheme hook wrapper
- implement useThemeColor helper
- configure `@/*` path alias

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f12e8c38832ab3ad514ae7eb1a00