### PR TITLE
Fix README instructions for src directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In the output, you'll find options to open the app in a
 - [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
 - [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
 
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
+You can start developing by editing the files inside the **src** directory. The project uses React Navigation for routing.
 
 
 ## Learn more


### PR DESCRIPTION
## Summary
- fix README to mention the `src` directory rather than the non-existent `app` directory

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f2acc900832abd55b64a884b8f02