### PR TITLE
Add simple quiz screen

### DIFF
--- a/src/components/QuizScreen.js
+++ b/src/components/QuizScreen.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+
+export default function QuizScreen({ navigation }) {
+  return (
+    <View>
+      <Text>What is 2 + 2?</Text>
+      <Button title="Show Result" onPress={() => navigation.navigate('Result')} />
+    </View>
+  );
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,23 +1,18 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { Text, View } from 'react-native';
+import QuizScreen from '../components/QuizScreen.js';
+import ResultScreen from '../components/ResultScreen';
+import type { RootStackParamList } from '../types/navigation';
 
-const Stack = createNativeStackNavigator();
-
-function DummyScreen() {
-  return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>It works!</Text>
-    </View>
-  );
-}
+const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function AppNavigator() {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Test" component={DummyScreen} />
+      <Stack.Navigator initialRouteName="Quiz">
+        <Stack.Screen name="Quiz" component={QuizScreen} />
+        <Stack.Screen name="Result" component={ResultScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
## Summary
- add a simple `QuizScreen.js` component
- wire `Quiz` and `Result` screens in `AppNavigator`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f5595650832aa51482fc9e896fad