### PR TITLE
Add initial testing setup

### DIFF
--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import HomeScreen from '../src/components/HomeScreen';
+
+it('renders Start Quiz button', () => {
+  const navigation = { navigate: jest.fn() } as any;
+  const { getByText } = render(<HomeScreen navigation={navigation} />);
+  expect(getByText('Start Quiz')).toBeTruthy();
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -42,7 +43,14 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@testing-library/react-native": "^14.1.0",
+    "@testing-library/jest-native": "^5.6.2",
+    "jest-expo": "^49.0.0"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add React Native Testing Library and jest-expo config
- create basic test for HomeScreen
- add babel configuration for tests

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f6db6fcc832ab5e7c351ea1fd615