### PR TITLE
Fix quiz restart, drop unused reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,6 @@ In the output, you'll find options to open the app in a
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
-## Get a fresh project
-
-When you're ready, run:
-
-```bash
-npm run reset-project
-```
-
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
-
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
-    "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",

--- a/src/components/QuizScreen.js
+++ b/src/components/QuizScreen.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
+
+const questions = [
+  {
+    question: 'Is React Native built by Facebook?',
+    options: ['Yes', 'No'],
+    answer: 'Yes',
+  },
+  {
+    question: 'Is Expo used for building React Native apps?',
+    options: ['Yes', 'No'],
+    answer: 'Yes',
+  },
+];
+
+export default function QuizScreen({ navigation }) {
+  const [current, setCurrent] = useState(0);
+  const [score, setScore] = useState(0);
+
+  const handleSelect = (option) => {
+    if (option === questions[current].answer) {
+      setScore(score + 1);
+    }
+    if (current + 1 < questions.length) {
+      setCurrent(current + 1);
+    } else {
+      navigation.navigate('Result', { score: score + (option === questions[current].answer ? 1 : 0), total: questions.length });
+    }
+  };
+
+  const q = questions[current];
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+      <Text>{q.question}</Text>
+      {q.options.map((option) => (
+        <Button key={option} title={option} onPress={() => handleSelect(option)} />
+      ))}
+    </View>
+  );
+}

--- a/src/components/ResultScreen.js
+++ b/src/components/ResultScreen.js
@@ -1,9 +1,11 @@
-import { Text, View } from 'react-native';
+import { View, Text, Button } from 'react-native';
 
-export default function ResultScreen() {
+export default function ResultScreen({ route, navigation }) {
+  const { score = 0, total = 0 } = route.params || {};
   return (
-    <View style={{ flex:1, alignItems:'center', justifyContent:'center' }}>
-      <Text>This is the Result Screen</Text>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 }}>
+      <Text>You scored {score} out of {total}!</Text>
+      <Button title="Play Again" onPress={() => navigation.replace('Quiz')} />
     </View>
   );
 }

--- a/src/constants/Colors.ts
+++ b/src/constants/Colors.ts
@@ -1,0 +1,16 @@
+export const Colors = {
+  light: {
+    text: '#000',
+    background: '#fff',
+    tint: '#0a7ea4',
+    icon: '#222',
+  },
+  dark: {
+    text: '#fff',
+    background: '#000',
+    tint: '#0a7ea4',
+    icon: '#fff',
+  },
+} as const;
+
+export type Theme = keyof typeof Colors;

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -1,0 +1,6 @@
+import { ColorSchemeName, useColorScheme as useRNColorScheme } from 'react-native';
+
+export function useColorScheme(): NonNullable<ColorSchemeName> | null {
+  // On web, useColorScheme may return undefined, so we coerce to null
+  return useRNColorScheme() ?? null;
+}

--- a/src/hooks/useThemeColor.ts
+++ b/src/hooks/useThemeColor.ts
@@ -1,0 +1,14 @@
+import { Colors, Theme } from '@/constants/Colors';
+import { useColorScheme } from './useColorScheme';
+
+export function useThemeColor(
+  props: { light?: string; dark?: string },
+  colorName: keyof (typeof Colors)['light']
+) {
+  const theme: Theme = useColorScheme() ?? 'light';
+  const colorFromProps = props[theme];
+  if (colorFromProps) {
+    return colorFromProps;
+  }
+  return Colors[theme][colorName];
+}


### PR DESCRIPTION
## Summary
- fix replay logic in ResultScreen
- remove unused reset-project npm script and update documentation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e396939c832aaae9b02aa51d597c