### PR TITLE
Implement quiz flow

### DIFF
--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -1,17 +1,51 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React from 'react';
-import { Button, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
 import { RootStackParamList } from '../types/navigation';
+import { questions } from '../data/questions';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
 
 const QuizScreen = ({ navigation }: Props) => {
+  const [current, setCurrent] = useState(0);
+  const [score, setScore] = useState(0);
+
+  const handleAnswer = (index: number) => {
+    const isCorrect = index === questions[current].correctAnswer;
+    const newScore = isCorrect ? score + 1 : score;
+    setScore(newScore);
+
+    const next = current + 1;
+    if (next < questions.length) {
+      setCurrent(next);
+    } else {
+      navigation.navigate('Result', { score: newScore, totalQuestions: questions.length });
+    }
+  };
+
+  const question = questions[current];
+
   return (
-    <View>
-      <Text>Quiz Screen</Text>
-      <Button title="Finish Quiz" onPress={() => navigation.navigate('Result')} />
+    <View style={styles.container}>
+      <Text style={styles.question}>{question.text}</Text>
+      {question.options.map((option, index) => (
+        <Button key={index} title={option} onPress={() => handleAnswer(index)} />
+      ))}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  question: {
+    fontSize: 20,
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+});
 
 export default QuizScreen;

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -5,11 +5,14 @@ import { RootStackParamList } from '../types/navigation';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
 
-export default function ResultScreen({ navigation }: Props) {
+export default function ResultScreen({ navigation, route }: Props) {
+  const { score, totalQuestions } = route.params;
 
   return (
     <View>
-      <Text>Result Screen</Text>
+      <Text>
+        Your Score: {score} / {totalQuestions}
+      </Text>
       <Button title="Go back to Home" onPress={() => navigation.navigate('Home')} />
     </View>
   );

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,0 +1,23 @@
+export type Question = {
+  text: string;
+  options: string[];
+  correctAnswer: number; // index of the correct option
+};
+
+export const questions: Question[] = [
+  {
+    text: 'What is 2 + 2?',
+    options: ['3', '4', '5', '6'],
+    correctAnswer: 1,
+  },
+  {
+    text: 'Which planet is known as the Red Planet?',
+    options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
+    correctAnswer: 1,
+  },
+  {
+    text: 'What is the capital of France?',
+    options: ['Berlin', 'London', 'Paris', 'Rome'],
+    correctAnswer: 2,
+  },
+];

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,5 +1,8 @@
 export type RootStackParamList = {
   Home: undefined;
   Quiz: undefined;
-  Result: undefined;
+  Result: {
+    score: number;
+    totalQuestions: number;
+  };
 };


### PR DESCRIPTION
## Summary
- add example questions
- implement quiz logic with score tracking
- type navigation params for result screen
- show final score in the result screen

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473aff10bc832a8bc5318de2d1021b