### PR TITLE
Add AsyncStorage high score tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "@react-native-async-storage/async-storage": "^1.23.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-async-storage/async-storage": "^1.23.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,4 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useFocusEffect } from '@react-navigation/native';
 import React from 'react';
 import {
   Image,
@@ -9,10 +10,19 @@ import {
   View,
 } from 'react-native';
 import { RootStackParamList } from '../types/navigation';
+import { getHighScore } from '../storage/highScore';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
+  const [highScore, setHighScoreState] = React.useState(0);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      getHighScore().then(setHighScoreState);
+    }, [])
+  );
+
   return (
     <ImageBackground
       source={require('../../assets/images/icon.png')} // bright background (can be your own)
@@ -28,6 +38,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
 
         {/* Colorful header */}
         <Text style={styles.title}>📚 A&A Lern-Mathe-App</Text>
+        <Text style={styles.highScore}>High Score: {highScore}</Text>
 
         {/* Wooden sign-like button */}
         <TouchableOpacity
@@ -90,5 +101,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     textAlign: 'center',
     letterSpacing: 1,
+  },
+  highScore: {
+    fontSize: 18,
+    marginBottom: 10,
+    color: '#333',
   },
 });

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
+import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { questions } from '../data/questions';
 
@@ -10,7 +11,7 @@ const QuizScreen = ({ navigation }: Props) => {
   const [current, setCurrent] = useState(0);
   const [score, setScore] = useState(0);
 
-  const handleAnswer = (index: number) => {
+  const handleAnswer = async (index: number) => {
     const isCorrect = index === questions[current].correctAnswer;
     const newScore = isCorrect ? score + 1 : score;
     setScore(newScore);
@@ -19,7 +20,14 @@ const QuizScreen = ({ navigation }: Props) => {
     if (next < questions.length) {
       setCurrent(next);
     } else {
-      navigation.navigate('Result', { score: newScore, totalQuestions: questions.length });
+      const highScore = await getHighScore();
+      if (newScore > highScore) {
+        await setHighScore(newScore);
+      }
+      navigation.navigate('Result', {
+        score: newScore,
+        totalQuestions: questions.length,
+      });
     }
   };
 

--- a/src/storage/highScore.ts
+++ b/src/storage/highScore.ts
@@ -1,0 +1,12 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const HIGH_SCORE_KEY = 'HIGH_SCORE';
+
+export const getHighScore = async (): Promise<number> => {
+  const value = await AsyncStorage.getItem(HIGH_SCORE_KEY);
+  return value ? Number(value) : 0;
+};
+
+export const setHighScore = async (score: number): Promise<void> => {
+  await AsyncStorage.setItem(HIGH_SCORE_KEY, score.toString());
+};


### PR DESCRIPTION
## Summary
- install `@react-native-async-storage/async-storage`
- add helpers to store and retrieve the quiz high score
- show the saved high score on the home screen
- update quiz flow to persist a new high score

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473e4cad24832a8f96845594577ada