### PR TITLE
Implement quiz review phase

### DIFF
--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useState } from 'react';
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Alert, Button, StyleSheet, Text, View } from 'react-native';
 import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { questions } from '../data/questions';
@@ -10,28 +10,95 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
 const QuizScreen = ({ navigation }: Props) => {
   const [current, setCurrent] = useState(0);
   const [score, setScore] = useState(0);
+  const [wrongQuestions, setWrongQuestions] = useState<number[]>([]);
+  const [reviewQueue, setReviewQueue] = useState<number[]>([]);
+  const [correctedQuestions, setCorrectedQuestions] = useState<number[]>([]);
+  const [reviewMode, setReviewMode] = useState(false);
+
+  const finishQuiz = async (finalScore: number) => {
+    const highScore = await getHighScore();
+    if (finalScore > highScore) {
+      await setHighScore(finalScore);
+    }
+    navigation.navigate('Result', {
+      score: finalScore,
+      totalQuestions: questions.length,
+    });
+  };
+
+  const showSummaryAndFinish = async (finalScore: number, corrected: number[]) => {
+    const summaryText = corrected
+      .map((i) => `- ${questions[i].text}`)
+      .join('\n');
+    await new Promise<void>((resolve) => {
+      Alert.alert('Corrected Questions', summaryText || 'None', [
+        {
+          text: 'Continue',
+          onPress: () => resolve(),
+        },
+      ]);
+    });
+    finishQuiz(finalScore);
+  };
 
   const handleAnswer = async (index: number) => {
-    const isCorrect = index === questions[current].correctAnswer;
-    const newScore = isCorrect ? score + 1 : score;
-    setScore(newScore);
+    const questionIndex = reviewMode ? reviewQueue[current] : current;
+    const isCorrect = index === questions[questionIndex].correctAnswer;
 
-    const next = current + 1;
-    if (next < questions.length) {
-      setCurrent(next);
-    } else {
-      const highScore = await getHighScore();
-      if (newScore > highScore) {
-        await setHighScore(newScore);
+    if (isCorrect) {
+      const newScore = score + 1;
+      setScore(newScore);
+
+      if (reviewMode) {
+        const newQueue = [...reviewQueue];
+        newQueue.splice(current, 1);
+        setReviewQueue(newQueue);
+        setCorrectedQuestions((prev) => [...prev, questionIndex]);
+
+        if (newQueue.length === 0) {
+          await showSummaryAndFinish(newScore, [...correctedQuestions, questionIndex]);
+          return;
+        } else if (current >= newQueue.length) {
+          setCurrent(0);
+        }
+      } else {
+        const next = current + 1;
+        if (next < questions.length) {
+          setCurrent(next);
+        } else if (wrongQuestions.length > 0) {
+          setReviewMode(true);
+          setReviewQueue(wrongQuestions);
+          setCurrent(0);
+        } else {
+          await finishQuiz(newScore);
+        }
       }
-      navigation.navigate('Result', {
-        score: newScore,
-        totalQuestions: questions.length,
-      });
+    } else {
+      if (reviewMode) {
+        const q = reviewQueue[current];
+        const newQueue = [...reviewQueue.slice(0, current), ...reviewQueue.slice(current + 1), q];
+        setReviewQueue(newQueue);
+        if (current >= newQueue.length) {
+          setCurrent(0);
+        }
+      } else {
+        const next = current + 1;
+        const newWrong = [...wrongQuestions, questionIndex];
+        setWrongQuestions(newWrong);
+
+        if (next < questions.length) {
+          setCurrent(next);
+        } else {
+          setReviewMode(true);
+          setReviewQueue(newWrong);
+          setCurrent(0);
+        }
+      }
     }
   };
 
-  const question = questions[current];
+  const questionIndexToShow = reviewMode ? reviewQueue[current] : current;
+  const question = questions[questionIndexToShow];
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- keep track of incorrect answers in `QuizScreen`
- repeat missed questions until they are answered correctly
- show an alert summarizing the corrected questions before navigating to the result screen

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847404e3c7c832a8e6213694e33674b