### PR TITLE
Add badge display to results

### DIFF
--- a/src/components/BadgeDisplay.tsx
+++ b/src/components/BadgeDisplay.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export type Badge = {
+  id: string;
+  title: string;
+};
+
+type Props = {
+  badges: Badge[];
+};
+
+const BadgeDisplay: React.FC<Props> = ({ badges }) => {
+  if (!badges.length) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Badges Earned:</Text>
+      <View style={styles.badges}>
+        {badges.map((badge) => (
+          <View key={badge.id} style={styles.badge}>
+            <Text style={styles.badgeText}>{badge.title}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+export default BadgeDisplay;
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 20,
+    alignItems: 'center',
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  badges: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    justifyContent: 'center',
+  },
+  badge: {
+    backgroundColor: '#f6c026',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  badgeText: {
+    color: '#000',
+    fontWeight: '700',
+  },
+});

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React from 'react';
 import { Button, Text, View } from 'react-native';
+import BadgeDisplay, { Badge } from './BadgeDisplay';
 import { RootStackParamList } from '../types/navigation';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
@@ -8,11 +9,29 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
 export default function ResultScreen({ navigation, route }: Props) {
   const { score, totalQuestions } = route.params;
 
+  const getEarnedBadges = (): Badge[] => {
+    const percentage = score / totalQuestions;
+
+    if (percentage === 1) {
+      return [{ id: 'gold', title: 'Gold Badge' }];
+    }
+    if (percentage >= 0.8) {
+      return [{ id: 'silver', title: 'Silver Badge' }];
+    }
+    if (percentage >= 0.5) {
+      return [{ id: 'bronze', title: 'Bronze Badge' }];
+    }
+    return [];
+  };
+
+  const badges = getEarnedBadges();
+
   return (
     <View>
       <Text>
         Your Score: {score} / {totalQuestions}
       </Text>
+      <BadgeDisplay badges={badges} />
       <Button title="Go back to Home" onPress={() => navigation.navigate('Home')} />
     </View>
   );


### PR DESCRIPTION
## Summary
- show badges earned based on quiz performance
- compute earned badges in ResultScreen

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684741a0bf10832aa03ef6607f179c17