### PR TITLE
Improve accessibility of home and collapsible components

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -16,7 +16,10 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
       <TouchableOpacity
         style={styles.heading}
         onPress={() => setIsOpen((value) => !value)}
-        activeOpacity={0.8}>
+        activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel={`Toggle ${title}`}
+      >
         <IconSymbol
           name="chevron.right"
           size={18}

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -28,6 +28,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
       source={require('../../assets/images/icon.png')} // bright background (can be your own)
       style={styles.background}
       resizeMode="cover"
+      accessibilityLabel="Colorful background"
     >
       <SafeAreaView style={styles.safeArea}>
         <Surface style={styles.overlay} elevation={4}>
@@ -35,6 +36,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
           <Image
             source={require('../../assets/images/adaptive-icon.png')}
             style={styles.logo}
+            accessibilityLabel="Mascot logo"
           />
 
           {/* Colorful header */}


### PR DESCRIPTION
## Summary
- add `accessibilityLabel` props to the images in `HomeScreen`
- give the `TouchableOpacity` in `Collapsible` button role and label

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684744e17e94832a828010755cc8edb5