### PR TITLE
Use react-native-paper for styled screens

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import { Provider as PaperProvider } from 'react-native-paper';
 import AppNavigator from './src/navigation/AppNavigator';
+import { paperTheme } from './src/constants/PaperTheme';
 
 export default function App() {
-  return <AppNavigator />;
+  return (
+    <PaperProvider theme={paperTheme}>
+      <AppNavigator />
+    </PaperProvider>
+  );
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "@react-native-async-storage/async-storage": "^1.23.0"
+    "@react-native-async-storage/async-storage": "^1.23.0",
+    "react-native-paper": "^5.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -5,10 +5,10 @@ import {
   Image,
   ImageBackground,
   StyleSheet,
-  Text,
-  TouchableOpacity,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Surface, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 
@@ -29,26 +29,26 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
       style={styles.background}
       resizeMode="cover"
     >
-      <View style={styles.overlay}>
-        {/* Cartoon mascot image */}
-        <Image
-          source={require('../../assets/images/adaptive-icon.png')}
-          style={styles.logo}
-        />
+      <SafeAreaView style={styles.safeArea}>
+        <Surface style={styles.overlay} elevation={4}>
+          {/* Cartoon mascot image */}
+          <Image
+            source={require('../../assets/images/adaptive-icon.png')}
+            style={styles.logo}
+          />
 
-        {/* Colorful header */}
-        <Text style={styles.title}>📚 A&A Lern-Mathe-App</Text>
-        <Text style={styles.highScore}>High Score: {highScore}</Text>
+          {/* Colorful header */}
+          <Text variant="headlineMedium" style={styles.title}>
+            📚 A&A Lern-Mathe-App
+          </Text>
+          <Text style={styles.highScore}>High Score: {highScore}</Text>
 
-        {/* Wooden sign-like button */}
-        <TouchableOpacity
-          style={styles.woodButton}
-          activeOpacity={0.85}
-          onPress={() => navigation.navigate('Quiz')}
-        >
-          <Text style={styles.buttonText}>▶️ Starte dein Quiz!</Text>
-        </TouchableOpacity>
-      </View>
+          {/* Start button */}
+          <Button mode="contained" onPress={() => navigation.navigate('Quiz')}>
+            Starte dein Quiz!
+          </Button>
+        </Surface>
+      </SafeAreaView>
     </ImageBackground>
   );
 };
@@ -61,12 +61,18 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: '#0066cc',
   },
+  safeArea: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
   overlay: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     padding: 24,
-    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 16,
+    backgroundColor: 'rgba(255, 255, 255, 0.95)',
   },
   logo: {
     width: 180,
@@ -80,27 +86,6 @@ const styles = StyleSheet.create({
     color: '#ff6600',
     marginBottom: 30,
     textAlign: 'center',
-  },
-  woodButton: {
-    backgroundColor: '#5C4033',
-    borderRadius: 12,
-    paddingVertical: 16,
-    paddingHorizontal: 28,
-    borderWidth: 3,
-    borderColor: '#3B2F2F',
-    shadowColor: '#000',
-    shadowOffset: { width: 4, height: 6 },
-    shadowOpacity: 0.4,
-    shadowRadius: 5,
-    elevation: 8,
-    transform: [{ rotate: '-1deg' }],
-  },
-  buttonText: {
-    color: '#fff9dc',
-    fontSize: 20,
-    fontWeight: '700',
-    textAlign: 'center',
-    letterSpacing: 1,
   },
   highScore: {
     fontSize: 18,

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -1,6 +1,8 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useState } from 'react';
-import { Alert, Button, StyleSheet, Text, View } from 'react-native';
+import { Alert, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Card, Text } from 'react-native-paper';
 import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { questions } from '../data/questions';
@@ -101,12 +103,25 @@ const QuizScreen = ({ navigation }: Props) => {
   const question = questions[questionIndexToShow];
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.question}>{question.text}</Text>
+    <SafeAreaView style={styles.container}>
+      <Card style={styles.card} elevation={2}>
+        <Card.Content>
+          <Text variant="titleLarge" style={styles.question}>
+            {question.text}
+          </Text>
+        </Card.Content>
+      </Card>
       {question.options.map((option, index) => (
-        <Button key={index} title={option} onPress={() => handleAnswer(index)} />
+        <Button
+          key={index}
+          mode="contained"
+          style={styles.option}
+          onPress={() => handleAnswer(index)}
+        >
+          {option}
+        </Button>
       ))}
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -116,10 +131,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     padding: 16,
   },
+  card: {
+    marginBottom: 12,
+  },
   question: {
     fontSize: 20,
     marginBottom: 12,
     textAlign: 'center',
+  },
+  option: {
+    marginVertical: 4,
   },
 });
 

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -1,6 +1,8 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React from 'react';
-import { Button, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Card, Text } from 'react-native-paper';
+import { StyleSheet } from 'react-native';
 import BadgeDisplay, { Badge } from './BadgeDisplay';
 import { RootStackParamList } from '../types/navigation';
 
@@ -27,13 +29,30 @@ export default function ResultScreen({ navigation, route }: Props) {
   const badges = getEarnedBadges();
 
   return (
-    <View>
-      <Text>
-        Your Score: {score} / {totalQuestions}
-      </Text>
-      <BadgeDisplay badges={badges} />
-      <Button title="Go back to Home" onPress={() => navigation.navigate('Home')} />
-    </View>
+    <SafeAreaView style={styles.container}>
+      <Card style={styles.card} elevation={2}>
+        <Card.Content>
+          <Text variant="titleMedium">
+            Your Score: {score} / {totalQuestions}
+          </Text>
+          <BadgeDisplay badges={badges} />
+        </Card.Content>
+      </Card>
+      <Button mode="contained" onPress={() => navigation.navigate('Home')}>
+        Go back to Home
+      </Button>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+});
 

--- a/src/constants/PaperTheme.ts
+++ b/src/constants/PaperTheme.ts
@@ -1,0 +1,14 @@
+import { MD3LightTheme } from 'react-native-paper';
+import { Colors } from './Colors';
+
+export const paperTheme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#0066cc',
+    secondary: '#ff6600',
+    background: Colors.light.background,
+    surface: '#ffffff',
+    onSurface: Colors.light.text,
+  },
+};


### PR DESCRIPTION
## Summary
- add react-native-paper dependency
- wrap app in paper provider with custom theme
- refactor HomeScreen, QuizScreen and ResultScreen for consistent styling and safe-area usage
- create PaperTheme configuration

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684743e0fde0832a94f4ea509da0763d