### PR TITLE
Move react-navigation dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,12 @@
         "react-native-screens": "~4.11.1",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native-stack": "^7.3.14"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
-        "@react-navigation/native": "^7.1.10",
-        "@react-navigation/native-stack": "^7.3.14",
         "@testing-library/jest-native": "5.4.3",
         "@testing-library/react-native": "^12.1.5",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-navigation/native": "^7.1.10",
+    "@react-navigation/native-stack": "^7.3.14"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@react-navigation/native": "^7.1.10",
-    "@react-navigation/native-stack": "^7.3.14",
     "@testing-library/jest-native": "5.4.3",
     "@testing-library/react-native": "^12.1.5",
     "@types/estree": "^1.0.8",


### PR DESCRIPTION
## Summary
- move `@react-navigation/native` and `@react-navigation/native-stack` from `devDependencies` to `dependencies`
- update lockfile accordingly

## Testing
- `npm install --no-audit --no-fund` *(fails: ENOTEMPTY rename error)*
- `npm test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68489ec8d534832a98b0986fd44a55df