### PR TITLE
Fix BadgeDisplay spacing

### DIFF
--- a/src/components/BadgeDisplay.tsx
+++ b/src/components/BadgeDisplay.tsx
@@ -44,7 +44,8 @@ const styles = StyleSheet.create({
   badges: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
+    // Using margin on each badge instead of the experimental `gap` property
+    // for consistent cross-platform spacing.
     justifyContent: 'center',
   },
   badge: {
@@ -52,6 +53,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 12,
+    margin: 4,
   },
   badgeText: {
     color: '#000',


### PR DESCRIPTION
## Summary
- avoid experimental `gap` in `BadgeDisplay`
- use margin and comment on styling choice

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2d5ade8832aa9e96d2b6cf32315