### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A&A Quiz App
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+
 This project is a simple quiz application built with [Expo](https://expo.dev) and React Native. It showcases a minimal navigation flow with a home screen, quiz questions and a results view that awards badges based on your score. Questions and high score data are stored locally so you can practise even without a network connection.
 
 ## Setup

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ResultScreen from '../src/components/ResultScreen';
+
+const renderScreen = (score: number, total: number = 5) =>
+  render(
+    <ResultScreen
+      navigation={{ navigate: jest.fn() } as any}
+      route={{ key: 'result', name: 'Result', params: { score, totalQuestions: total } } as any}
+    />
+  );
+
+describe('ResultScreen badges', () => {
+  it('awards gold badge for perfect score', () => {
+    const { getByText } = renderScreen(5, 5);
+    expect(getByText('Gold Badge')).toBeTruthy();
+  });
+
+  it('awards silver badge for >=80% score', () => {
+    const { getByText } = renderScreen(4, 5);
+    expect(getByText('Silver Badge')).toBeTruthy();
+  });
+
+  it('awards bronze badge for >=50% score', () => {
+    const { getByText } = renderScreen(3, 5);
+    expect(getByText('Bronze Badge')).toBeTruthy();
+  });
+
+  it('awards no badge below 50%', () => {
+    const { queryByText } = renderScreen(2, 5);
+    expect(queryByText('Badges Earned:')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add badge for CI to README
- test ResultScreen badge logic
- add GitHub Actions workflow for linting and tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a399011c832ab9598908171b4035