### PR TITLE
Add math question set with operation metadata

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -43,8 +43,9 @@ describe('QuizScreen', () => {
     // Answer first question incorrectly
     fireEvent.press(getByText(questions[0].options[0]));
     // Answer remaining questions correctly
-    fireEvent.press(getByText(questions[1].options[questions[1].correctAnswer]));
-    fireEvent.press(getByText(questions[2].options[questions[2].correctAnswer]));
+    for (let i = 1; i < questions.length; i++) {
+      fireEvent.press(getByText(questions[i].options[questions[i].correctAnswer]));
+    }
 
     // Review of question 0 should start
     // First repeat incorrectly

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import ResultScreen from '../src/components/ResultScreen';
+import { questions } from '../src/data/questions';
 
-const renderScreen = (score: number, total: number = 5) =>
+const TOTAL = questions.length;
+
+const renderScreen = (score: number, total: number = TOTAL) =>
   render(
     <ResultScreen
       navigation={{ navigate: jest.fn() } as any}
@@ -12,22 +15,25 @@ const renderScreen = (score: number, total: number = 5) =>
 
 describe('ResultScreen badges', () => {
   it('awards gold badge for perfect score', () => {
-    const { getByText } = renderScreen(5, 5);
+    const { getByText } = renderScreen(TOTAL, TOTAL);
     expect(getByText('Gold Badge')).toBeTruthy();
   });
 
   it('awards silver badge for >=80% score', () => {
-    const { getByText } = renderScreen(4, 5);
+    const silverScore = Math.ceil(TOTAL * 0.8);
+    const { getByText } = renderScreen(silverScore, TOTAL);
     expect(getByText('Silver Badge')).toBeTruthy();
   });
 
   it('awards bronze badge for >=50% score', () => {
-    const { getByText } = renderScreen(3, 5);
+    const bronzeScore = Math.ceil(TOTAL * 0.5);
+    const { getByText } = renderScreen(bronzeScore, TOTAL);
     expect(getByText('Bronze Badge')).toBeTruthy();
   });
 
   it('awards no badge below 50%', () => {
-    const { queryByText } = renderScreen(2, 5);
+    const belowBronze = Math.floor(TOTAL * 0.5) - 1;
+    const { queryByText } = renderScreen(belowBronze, TOTAL);
     expect(queryByText('Badges Earned:')).toBeNull();
   });
 });

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,23 +1,57 @@
-export type Question = {
+export type MathQuestion = {
   text: string;
   options: string[];
   correctAnswer: number; // index of the correct option
+  operation: 'add' | 'subtract' | 'multiply' | 'divide';
 };
 
-export const questions: Question[] = [
+export const questions: MathQuestion[] = [
   {
-    text: 'What is 2 + 2?',
+    text: 'What is 1 + 1?',
+    options: ['1', '2', '3', '4'],
+    correctAnswer: 1,
+    operation: 'add',
+  },
+  {
+    text: 'What is 3 + 4?',
+    options: ['6', '7', '8', '9'],
+    correctAnswer: 1, // 7
+    operation: 'add',
+  },
+  {
+    text: 'What is 5 - 2?',
+    options: ['2', '3', '4', '5'],
+    correctAnswer: 1, // 3
+    operation: 'subtract',
+  },
+  {
+    text: 'What is 9 - 4?',
     options: ['3', '4', '5', '6'],
-    correctAnswer: 1,
+    correctAnswer: 2, // 5
+    operation: 'subtract',
   },
   {
-    text: 'Which planet is known as the Red Planet?',
-    options: ['Earth', 'Mars', 'Jupiter', 'Venus'],
-    correctAnswer: 1,
+    text: 'What is 3 × 3?',
+    options: ['6', '8', '9', '12'],
+    correctAnswer: 2, // 9
+    operation: 'multiply',
   },
   {
-    text: 'What is the capital of France?',
-    options: ['Berlin', 'London', 'Paris', 'Rome'],
-    correctAnswer: 2,
+    text: 'What is 4 × 5?',
+    options: ['15', '18', '20', '25'],
+    correctAnswer: 2, // 20
+    operation: 'multiply',
+  },
+  {
+    text: 'What is 8 ÷ 2?',
+    options: ['2', '3', '4', '5'],
+    correctAnswer: 2, // 4
+    operation: 'divide',
+  },
+  {
+    text: 'What is 10 ÷ 5?',
+    options: ['1', '2', '3', '4'],
+    correctAnswer: 1, // 2
+    operation: 'divide',
   },
 ];


### PR DESCRIPTION
## Summary
- expand questions to cover add, subtract, multiply and divide
- expose `MathQuestion` interface with `operation` field
- adapt QuizScreen and ResultScreen tests to new questions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a9f1be00832ab4e18676ad06c1a3