### PR TITLE
Add per-operation scoring and badges

### DIFF
--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -3,7 +3,9 @@ import { render, fireEvent } from '@testing-library/react-native';
 import HomeScreen from '../src/components/HomeScreen';
 
 jest.mock('../src/storage/highScore', () => ({
-  getHighScore: jest.fn(() => Promise.resolve(0)),
+  getHighScore: jest.fn(() =>
+    Promise.resolve({ add: 0, subtract: 0, multiply: 0, divide: 0 })
+  ),
 }));
 
 jest.mock('@react-navigation/native', () => {

--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -2,10 +2,18 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import QuizScreen from '../src/components/QuizScreen';
 import { questions } from '../src/data/questions';
+import type { OperationCount } from '../src/types/score';
 import { Alert } from 'react-native';
 
+const TOTALS: OperationCount = questions.reduce<OperationCount>(
+  (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
+  { add: 0, subtract: 0, multiply: 0, divide: 0 }
+);
+
 jest.mock('../src/storage/highScore', () => ({
-  getHighScore: jest.fn(() => Promise.resolve(0)),
+  getHighScore: jest.fn(() =>
+    Promise.resolve({ add: 0, subtract: 0, multiply: 0, divide: 0 })
+  ),
   setHighScore: jest.fn(() => Promise.resolve()),
 }));
 
@@ -28,8 +36,8 @@ describe('QuizScreen', () => {
 
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith('Result', {
-        score: questions.length,
-        totalQuestions: questions.length,
+        scores: { add: 2, subtract: 2, multiply: 2, divide: 2 },
+        totals: TOTALS,
       })
     );
   });
@@ -56,8 +64,8 @@ describe('QuizScreen', () => {
     await waitFor(() => expect(alertSpy).toHaveBeenCalled());
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith('Result', {
-        score: questions.length,
-        totalQuestions: questions.length,
+        scores: { add: 2, subtract: 2, multiply: 2, divide: 2 },
+        totals: TOTALS,
       })
     );
   });

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -2,38 +2,48 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import ResultScreen from '../src/components/ResultScreen';
 import { questions } from '../src/data/questions';
+import type { OperationCount } from '../src/types/score';
 
-const TOTAL = questions.length;
+const TOTALS: OperationCount = questions.reduce<OperationCount>(
+  (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
+  { add: 0, subtract: 0, multiply: 0, divide: 0 }
+);
 
-const renderScreen = (score: number, total: number = TOTAL) =>
+const PERFECT: OperationCount = { ...TOTALS };
+
+const renderScreen = (scores: OperationCount, totals: OperationCount = TOTALS) =>
   render(
     <ResultScreen
       navigation={{ navigate: jest.fn() } as any}
-      route={{ key: 'result', name: 'Result', params: { score, totalQuestions: total } } as any}
+      route={{ key: 'result', name: 'Result', params: { scores, totals } } as any }
     />
   );
 
 describe('ResultScreen badges', () => {
   it('awards gold badge for perfect score', () => {
-    const { getByText } = renderScreen(TOTAL, TOTAL);
-    expect(getByText('Gold Badge')).toBeTruthy();
+    const { getByText } = renderScreen(PERFECT, TOTALS);
+    expect(getByText('Gold Badge (Addition)')).toBeTruthy();
+    expect(getByText('Gold Badge (Subtraction)')).toBeTruthy();
+    expect(getByText('Gold Badge (Multiplication)')).toBeTruthy();
+    expect(getByText('Gold Badge (Division)')).toBeTruthy();
   });
 
   it('awards silver badge for >=80% score', () => {
-    const silverScore = Math.ceil(TOTAL * 0.8);
-    const { getByText } = renderScreen(silverScore, TOTAL);
-    expect(getByText('Silver Badge')).toBeTruthy();
+    const totals = { add: 5, subtract: 5, multiply: 5, divide: 5 };
+    const scores = { add: 4, subtract: 4, multiply: 4, divide: 4 };
+    const { getByText } = renderScreen(scores, totals);
+    expect(getByText('Silver Badge (Addition)')).toBeTruthy();
   });
 
   it('awards bronze badge for >=50% score', () => {
-    const bronzeScore = Math.ceil(TOTAL * 0.5);
-    const { getByText } = renderScreen(bronzeScore, TOTAL);
-    expect(getByText('Bronze Badge')).toBeTruthy();
+    const scores = { add: 1, subtract: 1, multiply: 1, divide: 1 };
+    const { getByText } = renderScreen(scores, TOTALS);
+    expect(getByText('Bronze Badge (Addition)')).toBeTruthy();
   });
 
   it('awards no badge below 50%', () => {
-    const belowBronze = Math.floor(TOTAL * 0.5) - 1;
-    const { queryByText } = renderScreen(belowBronze, TOTAL);
+    const scores = { add: 0, subtract: 0, multiply: 0, divide: 0 };
+    const { queryByText } = renderScreen(scores, TOTALS);
     expect(queryByText('Badges Earned:')).toBeNull();
   });
 });

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -11,11 +11,17 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Surface, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
+import type { OperationCount } from '../types/score';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
-  const [highScore, setHighScoreState] = React.useState(0);
+  const [highScore, setHighScoreState] = React.useState<OperationCount>({
+    add: 0,
+    subtract: 0,
+    multiply: 0,
+    divide: 0,
+  });
 
   useFocusEffect(
     React.useCallback(() => {
@@ -43,7 +49,9 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
           <Text variant="headlineMedium" style={styles.title}>
             📚 A&A Lern-Mathe-App
           </Text>
-          <Text style={styles.highScore}>High Score: {highScore}</Text>
+          <Text style={styles.highScore}>
+            High Score: {Object.values(highScore).reduce((a, b) => a + b, 0)}
+          </Text>
 
           {/* Start button */}
           <Button mode="contained" onPress={() => navigation.navigate('Quiz')}>

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -5,25 +5,44 @@ import { Button, Card, Text } from 'react-native-paper';
 import { StyleSheet } from 'react-native';
 import BadgeDisplay, { Badge } from './BadgeDisplay';
 import { RootStackParamList } from '../types/navigation';
+import type { Operation, OperationCount } from '../types/score';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
 
 export default function ResultScreen({ navigation, route }: Props) {
-  const { score, totalQuestions } = route.params;
+  const { scores, totals } = route.params;
+
+  const operationNames: Record<Operation, string> = {
+    add: 'Addition',
+    subtract: 'Subtraction',
+    multiply: 'Multiplication',
+    divide: 'Division',
+  };
 
   const getEarnedBadges = (): Badge[] => {
-    const percentage = score / totalQuestions;
-
-    if (percentage === 1) {
-      return [{ id: 'gold', title: 'Gold Badge' }];
-    }
-    if (percentage >= 0.8) {
-      return [{ id: 'silver', title: 'Silver Badge' }];
-    }
-    if (percentage >= 0.5) {
-      return [{ id: 'bronze', title: 'Bronze Badge' }];
-    }
-    return [];
+    const badges: Badge[] = [];
+    (Object.keys(scores) as Operation[]).forEach((op) => {
+      const total = totals[op];
+      if (!total) {
+        return;
+      }
+      const percentage = scores[op] / total;
+      let level: 'Gold' | 'Silver' | 'Bronze' | null = null;
+      if (percentage === 1) {
+        level = 'Gold';
+      } else if (percentage >= 0.8) {
+        level = 'Silver';
+      } else if (percentage >= 0.5) {
+        level = 'Bronze';
+      }
+      if (level) {
+        badges.push({
+          id: `${op}-${level.toLowerCase()}`,
+          title: `${level} Badge (${operationNames[op]})`,
+        });
+      }
+    });
+    return badges;
   };
 
   const badges = getEarnedBadges();
@@ -33,7 +52,8 @@ export default function ResultScreen({ navigation, route }: Props) {
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleMedium">
-            Your Score: {score} / {totalQuestions}
+            Your Score: {Object.values(scores).reduce((a, b) => a + b, 0)} /{' '}
+            {Object.values(totals).reduce((a, b) => a + b, 0)}
           </Text>
           <BadgeDisplay badges={badges} />
         </Card.Content>

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -5,6 +5,8 @@ export type MathQuestion = {
   operation: 'add' | 'subtract' | 'multiply' | 'divide';
 };
 
+export type Operation = MathQuestion['operation'];
+
 export const questions: MathQuestion[] = [
   {
     text: 'What is 1 + 1?',

--- a/src/storage/highScore.ts
+++ b/src/storage/highScore.ts
@@ -1,12 +1,27 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { OperationCount } from '../types/score';
 
 const HIGH_SCORE_KEY = 'HIGH_SCORE';
 
-export const getHighScore = async (): Promise<number> => {
-  const value = await AsyncStorage.getItem(HIGH_SCORE_KEY);
-  return value ? Number(value) : 0;
+const DEFAULT_SCORES: OperationCount = {
+  add: 0,
+  subtract: 0,
+  multiply: 0,
+  divide: 0,
 };
 
-export const setHighScore = async (score: number): Promise<void> => {
-  await AsyncStorage.setItem(HIGH_SCORE_KEY, score.toString());
+export const getHighScore = async (): Promise<OperationCount> => {
+  const value = await AsyncStorage.getItem(HIGH_SCORE_KEY);
+  if (!value) {
+    return { ...DEFAULT_SCORES };
+  }
+  try {
+    return { ...DEFAULT_SCORES, ...JSON.parse(value) } as OperationCount;
+  } catch {
+    return { ...DEFAULT_SCORES };
+  }
+};
+
+export const setHighScore = async (scores: OperationCount): Promise<void> => {
+  await AsyncStorage.setItem(HIGH_SCORE_KEY, JSON.stringify(scores));
 };

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -2,7 +2,7 @@ export type RootStackParamList = {
   Home: undefined;
   Quiz: undefined;
   Result: {
-    score: number;
-    totalQuestions: number;
+    scores: import('./score').OperationCount;
+    totals: import('./score').OperationCount;
   };
 };

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -1,0 +1,5 @@
+import type { MathQuestion } from '../data/questions';
+
+export type Operation = MathQuestion['operation'];
+
+export type OperationCount = Record<Operation, number>;


### PR DESCRIPTION
## Summary
- store high scores for each math operation
- track quiz results per operation
- award badges per operation
- adjust home screen to sum per-operation high scores
- update tests for the new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab10ba68832aaeffd81a77cef69f