### PR TITLE
Add i18n support with language selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ npm test
 - Review mode for incorrectly answered questions
 - Badge system that rewards bronze, silver or gold depending on the final score
 - Works on Android, iOS and the web via Expo
+- Multi-language UI with runtime language selection
+
+## Adding translations
+
+Translation files live in `src/i18n`. Each file is named after its language code
+(for example `en.json` or `es.json`). To add a new language:
+
+1. Copy `src/i18n/en.json` to a new file like `fr.json`.
+2. Translate each value while keeping the same keys.
+3. Import the file and add it to the dictionary in `src/i18n/index.ts`.
+4. The new language will automatically appear in the menu on the home screen.
 
 ## Learn more
 

--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import HomeScreen from '../src/components/HomeScreen';
+import { LanguageProvider } from '../src/i18n/LanguageContext';
+import { setLocale, t } from '../src/i18n';
 
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
@@ -19,11 +21,14 @@ jest.mock('@react-navigation/native', () => {
 describe('HomeScreen', () => {
   it('navigates to Quiz on button press', () => {
     const navigate = jest.fn();
+    setLocale('en');
     const { getByText } = render(
-      <HomeScreen navigation={{ navigate } as any} route={{ key: '0', name: 'Home' } as any} />
+      <LanguageProvider>
+        <HomeScreen navigation={{ navigate } as any} route={{ key: '0', name: 'Home' } as any} />
+      </LanguageProvider>
     );
 
-    fireEvent.press(getByText('Starte dein Quiz!'));
+    fireEvent.press(getByText(t('startQuiz')));
     expect(navigate).toHaveBeenCalledWith('Quiz');
   });
 });

--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -4,6 +4,8 @@ import QuizScreen from '../src/components/QuizScreen';
 import { questions } from '../src/data/questions';
 import type { OperationCount } from '../src/types/score';
 import { Alert } from 'react-native';
+import { LanguageProvider } from '../src/i18n/LanguageContext';
+import { setLocale } from '../src/i18n';
 
 const TOTALS: OperationCount = questions.reduce<OperationCount>(
   (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
@@ -26,8 +28,11 @@ jest.spyOn(Alert, 'alert').mockImplementation((title, message, buttons) => {
 describe('QuizScreen', () => {
   it('navigates to Result with score after correct answers', async () => {
     const navigate = jest.fn();
+    setLocale('en');
     const { getByText } = render(
-      <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz' } as any} />
+      <LanguageProvider>
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz' } as any} />
+      </LanguageProvider>
     );
 
     for (const q of questions) {
@@ -44,8 +49,11 @@ describe('QuizScreen', () => {
   it('repeats incorrect questions until answered correctly and shows summary', async () => {
     const navigate = jest.fn();
     const alertSpy = jest.spyOn(Alert, 'alert');
+    setLocale('en');
     const { getByText } = render(
-      <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz' } as any} />
+      <LanguageProvider>
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz' } as any} />
+      </LanguageProvider>
     );
 
     // Answer first question incorrectly

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react-native';
 import ResultScreen from '../src/components/ResultScreen';
 import { questions } from '../src/data/questions';
 import type { OperationCount } from '../src/types/score';
+import { LanguageProvider } from '../src/i18n/LanguageContext';
+import { setLocale } from '../src/i18n';
 
 const TOTALS: OperationCount = questions.reduce<OperationCount>(
   (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
@@ -13,13 +15,16 @@ const PERFECT: OperationCount = { ...TOTALS };
 
 const renderScreen = (scores: OperationCount, totals: OperationCount = TOTALS) =>
   render(
-    <ResultScreen
-      navigation={{ navigate: jest.fn() } as any}
-      route={{ key: 'result', name: 'Result', params: { scores, totals } } as any }
-    />
+    <LanguageProvider>
+      <ResultScreen
+        navigation={{ navigate: jest.fn() } as any}
+        route={{ key: 'result', name: 'Result', params: { scores, totals } } as any }
+      />
+    </LanguageProvider>
   );
 
 describe('ResultScreen badges', () => {
+  beforeEach(() => setLocale('en'));
   it('awards gold badge for perfect score', () => {
     const { getByText } = renderScreen(PERFECT, TOTALS);
     expect(getByText('Gold Badge (Addition)')).toBeTruthy();

--- a/app.tsx
+++ b/app.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { Provider as PaperProvider } from 'react-native-paper';
 import AppNavigator from './src/navigation/AppNavigator';
 import { paperTheme } from './src/constants/PaperTheme';
+import { LanguageProvider } from './src/i18n/LanguageContext';
 
 export default function App() {
   return (
     <PaperProvider theme={paperTheme}>
-      <AppNavigator />
+      <LanguageProvider>
+        <AppNavigator />
+      </LanguageProvider>
     </PaperProvider>
   );
 }

--- a/src/components/BadgeDisplay.tsx
+++ b/src/components/BadgeDisplay.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { t } from '../i18n';
 
 export type Badge = {
   id: string;
@@ -17,7 +18,7 @@ const BadgeDisplay: React.FC<Props> = ({ badges }) => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.heading}>Badges Earned:</Text>
+      <Text style={styles.heading}>{t('badgesEarned')}</Text>
       <View style={styles.badges}>
         {badges.map((badge) => (
           <View key={badge.id} style={styles.badge}>

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -8,14 +8,18 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Surface, Text } from 'react-native-paper';
+import { Button, Surface, Text, Menu } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 import type { OperationCount } from '../types/score';
+import { t } from '../i18n';
+import { useLanguage, availableLanguages } from '../i18n/LanguageContext';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
+  const { language, setLanguage } = useLanguage();
+  const [menuVisible, setMenuVisible] = React.useState(false);
   const [highScore, setHighScoreState] = React.useState<OperationCount>({
     add: 0,
     subtract: 0,
@@ -34,7 +38,7 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
       source={require('../../assets/images/icon.png')} // bright background (can be your own)
       style={styles.background}
       resizeMode="cover"
-      accessibilityLabel="Colorful background"
+      accessibilityLabel={t('colorfulBackground')}
     >
       <SafeAreaView style={styles.safeArea}>
         <Surface style={styles.overlay} elevation={4}>
@@ -42,21 +46,44 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
           <Image
             source={require('../../assets/images/adaptive-icon.png')}
             style={styles.logo}
-            accessibilityLabel="Mascot logo"
+            accessibilityLabel={t('mascotLogo')}
           />
 
           {/* Colorful header */}
           <Text variant="headlineMedium" style={styles.title}>
-            📚 A&A Lern-Mathe-App
+            {t('title')}
           </Text>
           <Text style={styles.highScore}>
-            High Score: {Object.values(highScore).reduce((a, b) => a + b, 0)}
+            {t('highScore', { count: Object.values(highScore).reduce((a, b) => a + b, 0) })}
           </Text>
 
           {/* Start button */}
           <Button mode="contained" onPress={() => navigation.navigate('Quiz')}>
-            Starte dein Quiz!
+            {t('startQuiz')}
           </Button>
+
+          <View style={styles.langMenu}>
+            <Menu
+              visible={menuVisible}
+              onDismiss={() => setMenuVisible(false)}
+              anchor={
+                <Button mode="outlined" onPress={() => setMenuVisible(true)}>
+                  {t('language')}: {language.toUpperCase()}
+                </Button>
+              }
+            >
+              {availableLanguages.map((lang) => (
+                <Menu.Item
+                  key={lang}
+                  onPress={() => {
+                    setLanguage(lang);
+                    setMenuVisible(false);
+                  }}
+                  title={lang.toUpperCase()}
+                />
+              ))}
+            </Menu>
+          </View>
         </Surface>
       </SafeAreaView>
     </ImageBackground>
@@ -101,5 +128,8 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 10,
     color: '#333',
+  },
+  langMenu: {
+    marginTop: 16,
   },
 });

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -7,6 +7,7 @@ import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { questions } from '../data/questions';
 import type { OperationCount, Operation } from '../types/score';
+import { t } from '../i18n';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
 
@@ -60,9 +61,9 @@ const QuizScreen = ({ navigation }: Props) => {
       .map((i) => `- ${questions[i].text}`)
       .join('\n');
     await new Promise<void>((resolve) => {
-      Alert.alert('Corrected Questions', summaryText || 'None', [
+      Alert.alert(t('correctedQuestions'), summaryText || t('none'), [
         {
-          text: 'Continue',
+          text: t('continue'),
           onPress: () => resolve(),
         },
       ]);

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -6,17 +6,20 @@ import { StyleSheet } from 'react-native';
 import BadgeDisplay, { Badge } from './BadgeDisplay';
 import { RootStackParamList } from '../types/navigation';
 import type { Operation, OperationCount } from '../types/score';
+import { t } from '../i18n';
+import { useLanguage } from '../i18n/LanguageContext';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
 
 export default function ResultScreen({ navigation, route }: Props) {
   const { scores, totals } = route.params;
+  useLanguage();
 
   const operationNames: Record<Operation, string> = {
-    add: 'Addition',
-    subtract: 'Subtraction',
-    multiply: 'Multiplication',
-    divide: 'Division',
+    add: t('addition'),
+    subtract: t('subtraction'),
+    multiply: t('multiplication'),
+    divide: t('division'),
   };
 
   const getEarnedBadges = (): Badge[] => {
@@ -52,14 +55,16 @@ export default function ResultScreen({ navigation, route }: Props) {
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleMedium">
-            Your Score: {Object.values(scores).reduce((a, b) => a + b, 0)} /{' '}
-            {Object.values(totals).reduce((a, b) => a + b, 0)}
+            {t('yourScore', {
+              score: Object.values(scores).reduce((a, b) => a + b, 0),
+              total: Object.values(totals).reduce((a, b) => a + b, 0),
+            })}
           </Text>
           <BadgeDisplay badges={badges} />
         </Card.Content>
       </Card>
       <Button mode="contained" onPress={() => navigation.navigate('Home')}>
-        Go back to Home
+        {t('goHome')}
       </Button>
     </SafeAreaView>
   );

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState } from 'react';
+import * as Localization from 'expo-localization';
+import { setLocale, getLocale } from './index';
+
+export type LanguageContextValue = {
+  language: string;
+  setLanguage: (lang: string) => void;
+};
+
+const defaultLang = Localization.locale.split('-')[0];
+
+const LanguageContext = createContext<LanguageContextValue>({
+  language: defaultLang,
+  setLanguage: () => {},
+});
+
+export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [language, setLanguageState] = useState<string>(getLocale());
+
+  const update = (lang: string) => {
+    setLanguageState(lang);
+    setLocale(lang);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage: update }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,18 @@
+{
+  "title": "📚 A&A Math Learning App",
+  "highScore": "High Score: {{count}}",
+  "startQuiz": "Start Quiz",
+  "correctedQuestions": "Corrected Questions",
+  "none": "None",
+  "continue": "Continue",
+  "yourScore": "Your Score: {{score}} / {{total}}",
+  "goHome": "Go back to Home",
+  "badgesEarned": "Badges Earned:",
+  "addition": "Addition",
+  "subtraction": "Subtraction",
+  "multiplication": "Multiplication",
+  "division": "Division",
+  "colorfulBackground": "Colorful background",
+  "mascotLogo": "Mascot logo",
+  "language": "Language"
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,18 @@
+{
+  "title": "📚 App de Matemáticas A&A",
+  "highScore": "Puntuación máxima: {{count}}",
+  "startQuiz": "¡Comienza tu cuestionario!",
+  "correctedQuestions": "Preguntas corregidas",
+  "none": "Ninguna",
+  "continue": "Continuar",
+  "yourScore": "Tu puntuación: {{score}} / {{total}}",
+  "goHome": "Volver al inicio",
+  "badgesEarned": "Insignias obtenidas:",
+  "addition": "Adición",
+  "subtraction": "Sustracción",
+  "multiplication": "Multiplicación",
+  "division": "División",
+  "colorfulBackground": "Fondo colorido",
+  "mascotLogo": "Logotipo mascota",
+  "language": "Idioma"
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,33 @@
+import * as Localization from 'expo-localization';
+import en from './en.json';
+import es from './es.json';
+
+export type TranslationKey = keyof typeof en;
+
+type Dictionaries = Record<string, Record<TranslationKey, string>>;
+
+const dictionaries: Dictionaries = {
+  en,
+  es,
+};
+
+let locale = Localization.locale.split('-')[0];
+
+export const setLocale = (lang: string) => {
+  locale = lang;
+};
+
+export const getLocale = () => locale;
+
+export function t(key: TranslationKey, options?: Record<string, string | number>): string {
+  const dict = dictionaries[locale] || dictionaries.en;
+  let text = dict[key] || key;
+  if (options) {
+    Object.keys(options).forEach((k) => {
+      text = text.replace(`{{${k}}}`, String(options[k]));
+    });
+  }
+  return text;
+}
+
+export const availableLanguages = Object.keys(dictionaries);


### PR DESCRIPTION
## Summary
- introduce a simple i18n system with English and Spanish translations
- replace hard-coded UI text with translation lookups
- add a language menu on the Home screen
- wrap the app with a language provider
- document how to add new translations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848acd44b44832a86d7aedc74e79d56