### PR TITLE
Fix language menu import

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -13,7 +13,8 @@ import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 import type { OperationCount } from '../types/score';
 import { t } from '../i18n';
-import { useLanguage, availableLanguages } from '../i18n/LanguageContext';
+import { useLanguage } from '../i18n/LanguageContext';
+import { availableLanguages } from '../i18n';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 


### PR DESCRIPTION
## Summary
- import `availableLanguages` from the correct module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1ccd10fc832a81872e169c03b208