### PR TITLE
Fix expo-localization undefined locale issue

### DIFF
--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -7,7 +7,8 @@ export type LanguageContextValue = {
   setLanguage: (lang: string) => void;
 };
 
-const defaultLang = Localization.locale.split('-')[0];
+// `Localization.locale` may be undefined in certain environments (e.g. tests)
+const defaultLang = Localization.locale?.split('-')[0] ?? 'en';
 
 const LanguageContext = createContext<LanguageContextValue>({
   language: defaultLang,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -11,7 +11,10 @@ const dictionaries: Dictionaries = {
   es,
 };
 
-let locale = Localization.locale.split('-')[0];
+// If `Localization.locale` is undefined (for example during tests), default to English.
+const defaultLocale = Localization.locale?.split('-')[0] ?? 'en';
+
+let locale = defaultLocale;
 
 export const setLocale = (lang: string) => {
   locale = lang;


### PR DESCRIPTION
## Summary
- handle missing `Localization.locale`
- default to English when locale is not available

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2450bad0832a934146a8590c5b80