### PR TITLE
Add Secondary operation screen

### DIFF
--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -19,7 +19,7 @@ jest.mock('@react-navigation/native', () => {
 });
 
 describe('HomeScreen', () => {
-  it('navigates to Quiz on button press', () => {
+  it('navigates to Secondary on button press', () => {
     const navigate = jest.fn();
     setLocale('en');
     const { getByText } = render(
@@ -29,6 +29,6 @@ describe('HomeScreen', () => {
     );
 
     fireEvent.press(getByText(t('startQuiz')));
-    expect(navigate).toHaveBeenCalledWith('Quiz');
+    expect(navigate).toHaveBeenCalledWith('Secondary');
   });
 });

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Surface, Text, Menu } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
-import type { OperationCount, Operation } from '../types/score';
+import type { OperationCount } from '../types/score';
 import { t } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
 import { availableLanguages } from '../i18n';
@@ -21,8 +21,6 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const { language, setLanguage } = useLanguage();
   const [menuVisible, setMenuVisible] = React.useState(false);
-  const [opMenuVisible, setOpMenuVisible] = React.useState(false);
-  const [operation, setOperation] = React.useState<'all' | Operation>('all');
   const [highScore, setHighScoreState] = React.useState<OperationCount>({
     add: 0,
     subtract: 0,
@@ -63,60 +61,11 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
           {/* Start button */}
           <Button
             mode="contained"
-            onPress={() => navigation.navigate('Quiz', { operation })}
+            onPress={() => navigation.navigate('Secondary')}
           >
             {t('startQuiz')}
           </Button>
 
-          <View style={styles.langMenu}>
-            <Menu
-              visible={opMenuVisible}
-              onDismiss={() => setOpMenuVisible(false)}
-              anchor={
-                <Button mode="outlined" onPress={() => setOpMenuVisible(true)}>
-                  {operation === 'all'
-                    ? t('operation_all')
-                    : t(
-                        operation === 'add'
-                          ? 'addition'
-                          : operation === 'subtract'
-                          ? 'subtraction'
-                          : operation === 'multiply'
-                          ? 'multiplication'
-                          : 'division'
-                      )}
-                </Button>
-              }
-            >
-              <Menu.Item
-                onPress={() => {
-                  setOperation('all');
-                  setOpMenuVisible(false);
-                }}
-                title={t('operation_all')}
-              />
-              {(['add', 'subtract', 'multiply', 'divide'] as Operation[]).map(
-                (op) => (
-                  <Menu.Item
-                    key={op}
-                    onPress={() => {
-                      setOperation(op);
-                      setOpMenuVisible(false);
-                    }}
-                    title={t(
-                      op === 'add'
-                        ? 'addition'
-                        : op === 'subtract'
-                        ? 'subtraction'
-                        : op === 'multiply'
-                        ? 'multiplication'
-                        : 'division'
-                    )}
-                  />
-                )
-              )}
-            </Menu>
-          </View>
 
           <View style={styles.langMenu}>
             <Menu

--- a/src/components/SecondaryScreen.tsx
+++ b/src/components/SecondaryScreen.tsx
@@ -1,0 +1,57 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, IconButton, Text } from 'react-native-paper';
+import { RootStackParamList } from '../types/navigation';
+import { t } from '../i18n';
+import { useLanguage } from '../i18n/LanguageContext';
+
+export type SecondaryProps = NativeStackScreenProps<RootStackParamList, 'Secondary'>;
+
+const SecondaryScreen: React.FC<SecondaryProps> = ({ navigation }) => {
+  useLanguage();
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text variant="titleLarge">{t('selectOperation')}</Text>
+        <IconButton
+          icon="trophy"
+          onPress={() => navigation.navigate('HighScore' as never)}
+          accessibilityLabel={t('highScores')}
+        />
+      </View>
+      <Button mode="contained" style={styles.button} onPress={() => navigation.navigate('Quiz', { operation: 'add' })}>
+        {t('addition')}
+      </Button>
+      <Button mode="contained" style={styles.button} onPress={() => navigation.navigate('Quiz', { operation: 'subtract' })}>
+        {t('subtraction')}
+      </Button>
+      <Button mode="contained" style={styles.button} onPress={() => navigation.navigate('Quiz', { operation: 'multiply' })}>
+        {t('multiplication')}
+      </Button>
+      <Button mode="contained" style={styles.button} onPress={() => navigation.navigate('Quiz', { operation: 'divide' })}>
+        {t('division')}
+      </Button>
+    </SafeAreaView>
+  );
+};
+
+export default SecondaryScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  button: {
+    marginVertical: 4,
+  },
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -24,5 +24,7 @@
   "q7": "Was ist 8 ÷ 2?",
   "q8": "Was ist 10 ÷ 5?",
   "operation_all": "Alle"
+  ,"selectOperation": "Operation wählen",
+  "highScores": "Bestleistungen"
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,5 +24,7 @@
   "q7": "What is 8 ÷ 2?",
   "operation_all": "All",
   "q8": "What is 10 ÷ 5?"
+  ,"selectOperation": "Select operation",
+  "highScores": "High Scores"
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -22,7 +22,9 @@
   "q5": "¿Cuánto es 3 × 3?",
   "q6": "¿Cuánto es 4 × 5?",
   "q7": "¿Cuánto es 8 ÷ 2?",
-  "q8": "¿Cuánto es 10 ÷ 5?"
-  "operation_all": "Todas"
+  "q8": "¿Cuánto es 10 ÷ 5?",
+  "operation_all": "Todas",
+  "selectOperation": "Selecciona operación",
+  "highScores": "Puntuaciones altas"
 }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
 import HomeScreen from '../components/HomeScreen';
+import SecondaryScreen from '../components/SecondaryScreen';
 import QuizScreen from '../components/QuizScreen';
 import ResultScreen from '../components/ResultScreen';
 
@@ -15,6 +16,7 @@ export default function AppNavigator() {
     <NavigationContainer>
       <Stack.Navigator initialRouteName="Home">
         <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Secondary" component={SecondaryScreen} />
         <Stack.Screen name="Quiz" component={QuizScreen} />
         <Stack.Screen name="Result" component={ResultScreen} />
       </Stack.Navigator>

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,5 +1,6 @@
 export type RootStackParamList = {
   Home: undefined;
+  Secondary: undefined;
   Quiz: { operation?: import('./score').Operation | 'all' } | undefined;
   Result: {
     scores: import('./score').OperationCount;


### PR DESCRIPTION
## Summary
- add SecondaryScreen to select math operation
- update navigation stack
- update home screen to route to Secondary
- add translations for new screen
- adjust navigation types and tests

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing expo/tsconfig.base and libs)*

------
https://chatgpt.com/codex/tasks/task_e_68702339b7bc832ab3c8344ec2c73370