### PR TITLE
Add feedback overlay and modern theme

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
   background: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: '#0066cc',
+    backgroundColor: '#f2f2f2',
   },
   safeArea: {
     flex: 1,
@@ -125,14 +125,14 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 26,
     fontWeight: 'bold',
-    color: '#ff6600',
+    color: '#1a1a1a',
     marginBottom: 30,
     textAlign: 'center',
   },
   highScore: {
     fontSize: 18,
     marginBottom: 10,
-    color: '#333',
+    color: '#555',
   },
   langMenu: {
     marginTop: 16,

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useState, useMemo } from 'react';
-import { Alert, StyleSheet } from 'react-native';
+import { Alert, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
 import { getHighScore, setHighScore } from '../storage/highScore';
@@ -29,6 +29,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
   const [reviewQueue, setReviewQueue] = useState<number[]>([]);
   const [correctedQuestions, setCorrectedQuestions] = useState<number[]>([]);
   const [reviewMode, setReviewMode] = useState(false);
+  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
 
   const totals: OperationCount = useMemo(
     () =>
@@ -80,6 +81,9 @@ const QuizScreen = ({ navigation, route }: Props) => {
     const questionIndex = reviewMode ? reviewQueue[current] : current;
     const isCorrect = index === activeQuestions[questionIndex].correctAnswer;
     const op: Operation = activeQuestions[questionIndex].operation;
+
+    setFeedback(isCorrect ? 'correct' : 'wrong');
+    setTimeout(() => setFeedback(null), 800);
 
     if (isCorrect) {
       const newScore = score + 1;
@@ -143,6 +147,17 @@ const QuizScreen = ({ navigation, route }: Props) => {
 
   return (
     <SafeAreaView style={styles.container}>
+      {feedback && (
+        <View
+          style={[
+            styles.feedbackContainer,
+            feedback === 'correct' ? styles.correct : styles.wrong,
+          ]}
+          pointerEvents="none"
+        >
+          <Text style={styles.feedbackText}>{feedback === 'correct' ? '✓' : '✕'}</Text>
+        </View>
+      )}
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleLarge" style={styles.question}>
@@ -180,6 +195,24 @@ const styles = StyleSheet.create({
   },
   option: {
     marginVertical: 4,
+  },
+  feedbackContainer: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
+    borderRadius: 16,
+    padding: 8,
+  },
+  feedbackText: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  correct: {
+    backgroundColor: '#4caf50',
+  },
+  wrong: {
+    backgroundColor: '#f44336',
   },
 });
 

--- a/src/constants/PaperTheme.ts
+++ b/src/constants/PaperTheme.ts
@@ -5,10 +5,10 @@ export const paperTheme = {
   ...MD3LightTheme,
   colors: {
     ...MD3LightTheme.colors,
-    primary: '#0066cc',
-    secondary: '#ff6600',
-    background: Colors.light.background,
+    primary: '#1a1a1a',
+    secondary: '#5db075',
+    background: '#f2f2f2',
     surface: '#ffffff',
-    onSurface: Colors.light.text,
+    onSurface: '#222222',
   },
 };


### PR DESCRIPTION
## Summary
- give the theme darker neutral colors
- tweak HomeScreen colors
- show a check or X after each answer in QuizScreen

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872cfdab528832aadc9907721e437ad