### PR TITLE
Extend high score with player info

### DIFF
--- a/__tests__/HighScoreScreen.test.tsx
+++ b/__tests__/HighScoreScreen.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import HighScoreScreen from '../src/components/HighScoreScreen';
+import { LanguageProvider } from '../src/i18n/LanguageContext';
+import { setLocale, t } from '../src/i18n';
+
+jest.mock('../src/storage/highScore', () => ({
+  getHighScore: jest.fn(() =>
+    Promise.resolve({
+      add: { score: 2, playerName: 'Bob', date: '2024-01-01' },
+      subtract: { score: 1, playerName: 'Alice', date: '2024-01-02' },
+      multiply: { score: 0, playerName: '', date: '' },
+      divide: { score: 0, playerName: '', date: '' },
+    })
+  ),
+}));
+
+describe('HighScoreScreen', () => {
+  beforeEach(() => setLocale('en'));
+
+  it('displays stored name and date', async () => {
+    const { findByText } = render(
+      <LanguageProvider>
+        <HighScoreScreen navigation={{ goBack: jest.fn() } as any} route={{ key: 'h', name: 'HighScore' } as any} />
+      </LanguageProvider>
+    );
+    await findByText(`${t('addition')}: 2 (Bob 2024-01-01)`);
+    await findByText(`${t('subtraction')}: 1 (Alice 2024-01-02)`);
+  });
+});

--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -6,7 +6,12 @@ import { setLocale, t } from '../src/i18n';
 
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
-    Promise.resolve({ add: 0, subtract: 0, multiply: 0, divide: 0 })
+    Promise.resolve({
+      add: { score: 0, playerName: '', date: '' },
+      subtract: { score: 0, playerName: '', date: '' },
+      multiply: { score: 0, playerName: '', date: '' },
+      divide: { score: 0, playerName: '', date: '' },
+    })
   ),
 }));
 
@@ -28,7 +33,8 @@ describe('HomeScreen', () => {
       </LanguageProvider>
     );
 
+    fireEvent.changeText(getByText(t('enterName')), 'Alice');
     fireEvent.press(getByText(t('startQuiz')));
-    expect(navigate).toHaveBeenCalledWith('Selection');
+    expect(navigate).toHaveBeenCalledWith('Selection', { playerName: 'Alice' });
   });
 });

--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -14,7 +14,12 @@ const TOTALS: OperationCount = questions.reduce<OperationCount>(
 
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
-    Promise.resolve({ add: 0, subtract: 0, multiply: 0, divide: 0 })
+    Promise.resolve({
+      add: { score: 0, playerName: '', date: '' },
+      subtract: { score: 0, playerName: '', date: '' },
+      multiply: { score: 0, playerName: '', date: '' },
+      divide: { score: 0, playerName: '', date: '' },
+    })
   ),
   setHighScore: jest.fn(() => Promise.resolve()),
 }));
@@ -26,7 +31,7 @@ describe('QuizScreen', () => {
     setLocale('en');
     const { getByText } = render(
       <LanguageProvider>
-        <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz' } as any} />
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz', params: { playerName: 'Bob' } } as any} />
       </LanguageProvider>
     );
 
@@ -40,13 +45,19 @@ describe('QuizScreen', () => {
         totals: TOTALS,
       })
     );
+    const { setHighScore } = require('../src/storage/highScore');
+    expect(setHighScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        add: expect.objectContaining({ playerName: 'Bob' }),
+      })
+    );
   });
   it('ends the quiz when a cycle contains mistakes', async () => {
     const navigate = jest.fn();
     setLocale('en');
     const { getByText } = render(
       <LanguageProvider>
-        <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz' } as any} />
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz', params: { playerName: 'Bob' } } as any} />
       </LanguageProvider>
     );
 

--- a/__tests__/SelectionScreen.test.tsx
+++ b/__tests__/SelectionScreen.test.tsx
@@ -11,25 +11,25 @@ describe('SelectionScreen', () => {
     const navigate = jest.fn();
     const { getByText } = render(
       <LanguageProvider>
-        <SelectionScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Selection' } as any} />
+        <SelectionScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Selection', params: { playerName: 'Bob' } } as any} />
       </LanguageProvider>
     );
 
     fireEvent.press(getByText(t('addition')));
-    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'add' });
+    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'add', playerName: 'Bob' });
     fireEvent.press(getByText(t('subtraction')));
-    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'subtract' });
+    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'subtract', playerName: 'Bob' });
     fireEvent.press(getByText(t('multiplication')));
-    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'multiply' });
+    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'multiply', playerName: 'Bob' });
     fireEvent.press(getByText(t('division')));
-    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'divide' });
+    expect(navigate).toHaveBeenCalledWith('Quiz', { operation: 'divide', playerName: 'Bob' });
   });
 
   it('record button navigates to HighScoreScreen', () => {
     const navigate = jest.fn();
     const { getByText } = render(
       <LanguageProvider>
-        <SelectionScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Selection' } as any} />
+        <SelectionScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Selection', params: { playerName: 'Bob' } } as any} />
       </LanguageProvider>
     );
 

--- a/src/components/HighScoreScreen.tsx
+++ b/src/components/HighScoreScreen.tsx
@@ -6,7 +6,7 @@ import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 import { t } from '../i18n';
-import type { OperationCount } from '../types/score';
+import type { OperationRecordMap } from '../types/score';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },
@@ -16,11 +16,11 @@ const styles = StyleSheet.create({
 type Props = NativeStackScreenProps<RootStackParamList, 'HighScore'>;
 
 const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
-  const [scores, setScores] = useState<OperationCount>({
-    add: 0,
-    subtract: 0,
-    multiply: 0,
-    divide: 0,
+  const [scores, setScores] = useState<OperationRecordMap>({
+    add: { score: 0, playerName: '', date: '' },
+    subtract: { score: 0, playerName: '', date: '' },
+    multiply: { score: 0, playerName: '', date: '' },
+    divide: { score: 0, playerName: '', date: '' },
   });
 
   useEffect(() => {
@@ -32,10 +32,18 @@ const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleLarge">{t('highScores')}</Text>
-          <Text>{t('addition')}: {scores.add}</Text>
-          <Text>{t('subtraction')}: {scores.subtract}</Text>
-          <Text>{t('multiplication')}: {scores.multiply}</Text>
-          <Text>{t('division')}: {scores.divide}</Text>
+          <Text>
+            {t('addition')}: {scores.add.score} ({scores.add.playerName} {scores.add.date})
+          </Text>
+          <Text>
+            {t('subtraction')}: {scores.subtract.score} ({scores.subtract.playerName} {scores.subtract.date})
+          </Text>
+          <Text>
+            {t('multiplication')}: {scores.multiply.score} ({scores.multiply.playerName} {scores.multiply.date})
+          </Text>
+          <Text>
+            {t('division')}: {scores.divide.score} ({scores.divide.playerName} {scores.divide.date})
+          </Text>
         </Card.Content>
       </Card>
       <Button mode="contained" onPress={() => navigation.goBack()}>

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -8,10 +8,10 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Surface, Text, Menu } from 'react-native-paper';
+import { Button, Surface, Text, Menu, TextInput } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
-import type { OperationCount } from '../types/score';
+import type { OperationRecordMap } from '../types/score';
 import { t } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
 import { availableLanguages } from '../i18n';
@@ -21,12 +21,13 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const { language, setLanguage } = useLanguage();
   const [menuVisible, setMenuVisible] = React.useState(false);
-  const [highScore, setHighScoreState] = React.useState<OperationCount>({
-    add: 0,
-    subtract: 0,
-    multiply: 0,
-    divide: 0,
+  const [highScore, setHighScoreState] = React.useState<OperationRecordMap>({
+    add: { score: 0, playerName: '', date: '' },
+    subtract: { score: 0, playerName: '', date: '' },
+    multiply: { score: 0, playerName: '', date: '' },
+    divide: { score: 0, playerName: '', date: '' },
   });
+  const [playerName, setPlayerName] = React.useState('');
 
   useFocusEffect(
     React.useCallback(() => {
@@ -55,13 +56,23 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
             {t('title')}
           </Text>
           <Text style={styles.highScore}>
-            {t('highScore', { count: Object.values(highScore).reduce((a, b) => a + b, 0) })}
+            {t('highScore', {
+              count: Object.values(highScore).reduce((a, b) => a + b.score, 0),
+            })}
           </Text>
+
+          <TextInput
+            label={t('enterName')}
+            value={playerName}
+            onChangeText={setPlayerName}
+            style={styles.input}
+          />
 
           {/* Start button */}
           <Button
             mode="contained"
-            onPress={() => navigation.navigate('Selection')}
+            onPress={() => navigation.navigate('Selection', { playerName })}
+            disabled={!playerName.trim()}
           >
             {t('startQuiz')}
           </Button>
@@ -133,6 +144,10 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 10,
     color: '#555',
+  },
+  input: {
+    width: '100%',
+    marginBottom: 16,
   },
   langMenu: {
     marginTop: 16,

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -6,13 +6,14 @@ import { Button, Card, Text } from 'react-native-paper';
 import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { generateQuestions } from '../data/questions';
-import type { OperationCount, Operation } from '../types/score';
+import type { OperationCount, Operation, OperationRecordMap } from '../types/score';
 import { t, type TranslationKey } from '../i18n';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
 
 const QuizScreen = ({ navigation, route }: Props) => {
   const allQuestions = useMemo(() => generateQuestions(), []);
+  const { playerName } = route.params;
   const selectedOp = route.params?.operation ?? 'all';
   const activeQuestions =
     selectedOp === 'all'
@@ -41,11 +42,15 @@ const QuizScreen = ({ navigation, route }: Props) => {
 
   const finishQuiz = async (finalScores: OperationCount, finalTotals: OperationCount) => {
     const highScore = await getHighScore();
-    const updated: OperationCount = { ...highScore };
+    const updated: OperationRecordMap = { ...highScore };
     let changed = false;
     (Object.keys(finalScores) as Operation[]).forEach((op) => {
-      if (finalScores[op] > highScore[op]) {
-        updated[op] = finalScores[op];
+      if (finalScores[op] > highScore[op].score) {
+        updated[op] = {
+          score: finalScores[op],
+          playerName,
+          date: new Date().toISOString(),
+        };
         changed = true;
       }
     });

--- a/src/components/SelectionScreen.tsx
+++ b/src/components/SelectionScreen.tsx
@@ -15,46 +15,52 @@ const styles = StyleSheet.create({
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Selection'>;
 
-const SelectionScreen: React.FC<Props> = ({ navigation }) => (
-  <SafeAreaView style={styles.container}>
-    <Text variant="titleLarge" style={styles.title}>
-      {t('selectOperation')}
-    </Text>
-    <Button mode="contained" onPress={() => navigation.navigate('Quiz', { operation: 'add' })}>
-      {t('addition')}
-    </Button>
-    <Button
-      mode="contained"
-      style={styles.button}
-      onPress={() => navigation.navigate('Quiz', { operation: 'subtract' })}
-    >
-      {t('subtraction')}
-    </Button>
-    <Button
-      mode="contained"
-      style={styles.button}
-      onPress={() => navigation.navigate('Quiz', { operation: 'multiply' })}
-    >
-      {t('multiplication')}
-    </Button>
-    <Button
-      mode="contained"
-      style={styles.button}
-      onPress={() => navigation.navigate('Quiz', { operation: 'divide' })}
-    >
-      {t('division')}
-    </Button>
-    <Button
-      mode="outlined"
-      style={styles.button}
-      onPress={() => navigation.navigate('HighScore')}
-      icon={({ size, color }) => (
-        <MaterialCommunityIcons name="trophy" size={size} color={color} />
-      )}
-    >
-      {t('viewRecords')}
-    </Button>
-  </SafeAreaView>
-);
+const SelectionScreen: React.FC<Props> = ({ navigation, route }) => {
+  const { playerName } = route.params;
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text variant="titleLarge" style={styles.title}>
+        {t('selectOperation')}
+      </Text>
+      <Button
+        mode="contained"
+        onPress={() => navigation.navigate('Quiz', { operation: 'add', playerName })}
+      >
+        {t('addition')}
+      </Button>
+      <Button
+        mode="contained"
+        style={styles.button}
+        onPress={() => navigation.navigate('Quiz', { operation: 'subtract', playerName })}
+      >
+        {t('subtraction')}
+      </Button>
+      <Button
+        mode="contained"
+        style={styles.button}
+        onPress={() => navigation.navigate('Quiz', { operation: 'multiply', playerName })}
+      >
+        {t('multiplication')}
+      </Button>
+      <Button
+        mode="contained"
+        style={styles.button}
+        onPress={() => navigation.navigate('Quiz', { operation: 'divide', playerName })}
+      >
+        {t('division')}
+      </Button>
+      <Button
+        mode="outlined"
+        style={styles.button}
+        onPress={() => navigation.navigate('HighScore')}
+        icon={({ size, color }) => (
+          <MaterialCommunityIcons name="trophy" size={size} color={color} />
+        )}
+      >
+        {t('viewRecords')}
+      </Button>
+    </SafeAreaView>
+  );
+};
 
 export default SelectionScreen;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -30,6 +30,7 @@
   "operation_all": "Alle",
   "selectOperation": "Operation wählen",
   "viewRecords": "Rekorde ansehen",
-  "highScores": "Rekorde"
+  "highScores": "Rekorde",
+  "enterName": "Gib deinen Namen ein"
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,6 +30,7 @@
   "divideQuestion": "What is {{a}} ÷ {{b}}?",
   "selectOperation": "Select Operation",
   "viewRecords": "View Records",
-  "highScores": "High Scores"
+  "highScores": "High Scores",
+  "enterName": "Enter your name"
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -30,6 +30,7 @@
   "operation_all": "Todas",
   "selectOperation": "Seleccionar operación",
   "viewRecords": "Ver récords",
-  "highScores": "Récords"
+  "highScores": "Récords",
+  "enterName": "Ingresa tu nombre"
 }
 

--- a/src/storage/highScore.ts
+++ b/src/storage/highScore.ts
@@ -1,27 +1,27 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { OperationCount } from '../types/score';
+import type { OperationRecordMap } from '../types/score';
 
 const HIGH_SCORE_KEY = 'HIGH_SCORE';
 
-const DEFAULT_SCORES: OperationCount = {
-  add: 0,
-  subtract: 0,
-  multiply: 0,
-  divide: 0,
+const DEFAULT_SCORES: OperationRecordMap = {
+  add: { score: 0, playerName: '', date: '' },
+  subtract: { score: 0, playerName: '', date: '' },
+  multiply: { score: 0, playerName: '', date: '' },
+  divide: { score: 0, playerName: '', date: '' },
 };
 
-export const getHighScore = async (): Promise<OperationCount> => {
+export const getHighScore = async (): Promise<OperationRecordMap> => {
   const value = await AsyncStorage.getItem(HIGH_SCORE_KEY);
   if (!value) {
     return { ...DEFAULT_SCORES };
   }
   try {
-    return { ...DEFAULT_SCORES, ...JSON.parse(value) } as OperationCount;
+    return { ...DEFAULT_SCORES, ...JSON.parse(value) } as OperationRecordMap;
   } catch {
     return { ...DEFAULT_SCORES };
   }
 };
 
-export const setHighScore = async (scores: OperationCount): Promise<void> => {
+export const setHighScore = async (scores: OperationRecordMap): Promise<void> => {
   await AsyncStorage.setItem(HIGH_SCORE_KEY, JSON.stringify(scores));
 };

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,8 +1,11 @@
 export type RootStackParamList = {
   Home: undefined;
-  Selection: undefined;
+  Selection: { playerName: string };
   HighScore: undefined;
-  Quiz: { operation?: import('./score').Operation | 'all' } | undefined;
+  Quiz: {
+    operation?: import('./score').Operation | 'all';
+    playerName: string;
+  };
   Result: {
     scores: import('./score').OperationCount;
     totals: import('./score').OperationCount;

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -1,3 +1,11 @@
 import type { Operation } from '../data/questions';
 
 export type OperationCount = Record<Operation, number>;
+
+export type OperationRecord = {
+  score: number;
+  playerName: string;
+  date: string;
+};
+
+export type OperationRecordMap = Record<Operation, OperationRecord>;


### PR DESCRIPTION
## Summary
- add text input for player name on HomeScreen
- pass player name through navigation params
- store player name and date in AsyncStorage
- display stored name and date on the high score screen
- update tests to handle new parameters and add HighScoreScreen test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872decd11b4832a8cdc758e77d5e053