### PR TITLE
Remove unused high score from home screen

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,5 +1,4 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useFocusEffect } from '@react-navigation/native';
 import React from 'react';
 import {
   Image,
@@ -10,8 +9,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Surface, Text, Menu, TextInput } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
-import { getHighScore } from '../storage/highScore';
-import type { OperationRecordMap } from '../types/score';
 import { t } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
 import { availableLanguages } from '../i18n';
@@ -21,19 +18,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const { language, setLanguage } = useLanguage();
   const [menuVisible, setMenuVisible] = React.useState(false);
-  const [highScore, setHighScoreState] = React.useState<OperationRecordMap>({
-    add: { score: 0, playerName: '', date: '' },
-    subtract: { score: 0, playerName: '', date: '' },
-    multiply: { score: 0, playerName: '', date: '' },
-    divide: { score: 0, playerName: '', date: '' },
-  });
   const [playerName, setPlayerName] = React.useState('');
-
-  useFocusEffect(
-    React.useCallback(() => {
-      getHighScore().then(setHighScoreState);
-    }, [])
-  );
 
   return (
     <ImageBackground
@@ -54,11 +39,6 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
           {/* Colorful header */}
           <Text variant="headlineMedium" style={styles.title}>
             {t('title')}
-          </Text>
-          <Text style={styles.highScore}>
-            {t('highScore', {
-              count: Object.values(highScore).reduce((a, b) => a + b.score, 0),
-            })}
           </Text>
 
           <TextInput
@@ -139,11 +119,6 @@ const styles = StyleSheet.create({
     color: '#1a1a1a',
     marginBottom: 30,
     textAlign: 'center',
-  },
-  highScore: {
-    fontSize: 18,
-    marginBottom: 10,
-    color: '#555',
   },
   input: {
     width: '100%',

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1,6 +1,5 @@
 {
   "title": "📚 A&A Mathematik Lern-App",
-  "highScore": "Höchste Punktzahl: {{count}}",
   "startQuiz": "Quiz starten",
   "correctedQuestions": "Korrigierte Fragen",
   "none": "Keine",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,6 +1,5 @@
 {
   "title": "📚 A&A Math Learning App",
-  "highScore": "High Score: {{count}}",
   "startQuiz": "Start Quiz",
   "correctedQuestions": "Corrected Questions",
   "none": "None",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,6 +1,5 @@
 {
   "title": "📚 App de Matemáticas A&A",
-  "highScore": "Puntuación máxima: {{count}}",
   "startQuiz": "¡Comienza tu cuestionario!",
   "correctedQuestions": "Preguntas corregidas",
   "none": "Ninguna",


### PR DESCRIPTION
## Summary
- remove high score state and text from `HomeScreen`
- drop unused `highScore` translation key in all dictionaries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e38da054832a8970e9f16277651e