### PR TITLE
Use dialog for name entry

### DIFF
--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -24,17 +24,18 @@ jest.mock('@react-navigation/native', () => {
 });
 
 describe('HomeScreen', () => {
-  it('navigates to Selection on button press', () => {
+  it('navigates to Selection after entering name in dialog', () => {
     const navigate = jest.fn();
     setLocale('en');
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <LanguageProvider>
         <HomeScreen navigation={{ navigate } as any} route={{ key: '0', name: 'Home' } as any} />
       </LanguageProvider>
     );
 
-    fireEvent.changeText(getByText(t('enterName')), 'Alice');
     fireEvent.press(getByText(t('startQuiz')));
+    fireEvent.changeText(getByTestId('playerNameInput'), 'Alice');
+    fireEvent.press(getByText(t('continue')));
     expect(navigate).toHaveBeenCalledWith('Selection', { playerName: 'Alice' });
   });
 });

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -7,7 +7,15 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Surface, Text, Menu, TextInput } from 'react-native-paper';
+import {
+  Button,
+  Surface,
+  Text,
+  Menu,
+  TextInput,
+  Dialog,
+  Portal,
+} from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { t } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
@@ -19,6 +27,16 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const { language, setLanguage } = useLanguage();
   const [menuVisible, setMenuVisible] = React.useState(false);
   const [playerName, setPlayerName] = React.useState('');
+  const [dialogVisible, setDialogVisible] = React.useState(false);
+
+  const handleStartPress = () => setDialogVisible(true);
+
+  const handleSubmitName = () => {
+    if (playerName.trim()) {
+      setDialogVisible(false);
+      navigation.navigate('Selection', { playerName });
+    }
+  };
 
   return (
     <ImageBackground
@@ -41,21 +59,30 @@ const HomeScreen: React.FC<Props> = ({ navigation }) => {
             {t('title')}
           </Text>
 
-          <TextInput
-            label={t('enterName')}
-            value={playerName}
-            onChangeText={setPlayerName}
-            style={styles.input}
-          />
-
           {/* Start button */}
-          <Button
-            mode="contained"
-            onPress={() => navigation.navigate('Selection', { playerName })}
-            disabled={!playerName.trim()}
-          >
+          <Button mode="contained" onPress={handleStartPress}>
             {t('startQuiz')}
           </Button>
+
+          <Portal>
+            <Dialog visible={dialogVisible} onDismiss={() => setDialogVisible(false)}>
+              <Dialog.Title>{t('enterName')}</Dialog.Title>
+              <Dialog.Content>
+                <TextInput
+                  label={t('enterName')}
+                  value={playerName}
+                  onChangeText={setPlayerName}
+                  style={styles.input}
+                  testID="playerNameInput"
+                />
+              </Dialog.Content>
+              <Dialog.Actions>
+                <Button onPress={handleSubmitName} disabled={!playerName.trim()}>
+                  {t('continue')}
+                </Button>
+              </Dialog.Actions>
+            </Dialog>
+          </Portal>
 
 
           <View style={styles.langMenu}>


### PR DESCRIPTION
## Summary
- switch `HomeScreen` to open a dialog for entering the player name
- adapt test for new dialog workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e9aeff14832aab84906a95fb481d