### PR TITLE
Randomize quiz question generation

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -68,7 +68,8 @@ describe('QuizScreen', () => {
     const cycleScores: OperationCount = { ...cycleTotals };
     cycleScores[questions[0].operation] -= 1;
 
-    fireEvent.press(getByText(questions[0].options[0]));
+    const wrongIndex = (questions[0].correctAnswer + 1) % questions[0].options.length;
+    fireEvent.press(getByText(questions[0].options[wrongIndex]));
     for (let i = 1; i < 10; i++) {
       fireEvent.press(getByText(questions[i].options[questions[i].correctAnswer]));
     }

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -9,6 +9,14 @@ export type MathQuestion = {
   operation: Operation;
 };
 
+function shuffleArray<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 export function generateQuestions(): MathQuestion[] {
   const questions: MathQuestion[] = [];
 
@@ -16,12 +24,19 @@ export function generateQuestions(): MathQuestion[] {
     for (let b = 1; b <= 10; b++) {
       // Addition
       const addResult = a + b;
+      const addOptions = [
+        String(addResult - 1),
+        String(addResult),
+        String(addResult + 1),
+        String(addResult + 2),
+      ];
+      shuffleArray(addOptions);
       questions.push({
         textKey: 'addQuestion',
         a,
         b,
-        options: [String(addResult - 1), String(addResult), String(addResult + 1), String(addResult + 2)],
-        correctAnswer: 1,
+        options: addOptions,
+        correctAnswer: addOptions.indexOf(String(addResult)),
         operation: 'add',
       });
 
@@ -29,39 +44,60 @@ export function generateQuestions(): MathQuestion[] {
       const minuend = a >= b ? a : b;
       const subtrahend = a >= b ? b : a;
       const subResult = minuend - subtrahend;
+      const subOptions = [
+        String(subResult - 1),
+        String(subResult),
+        String(subResult + 1),
+        String(subResult + 2),
+      ];
+      shuffleArray(subOptions);
       questions.push({
         textKey: 'subtractQuestion',
         a: minuend,
         b: subtrahend,
-        options: [String(subResult - 1), String(subResult), String(subResult + 1), String(subResult + 2)],
-        correctAnswer: 1,
+        options: subOptions,
+        correctAnswer: subOptions.indexOf(String(subResult)),
         operation: 'subtract',
       });
 
       // Multiplication
       const mulResult = a * b;
+      const mulOptions = [
+        String(mulResult - 1),
+        String(mulResult),
+        String(mulResult + 1),
+        String(mulResult + 2),
+      ];
+      shuffleArray(mulOptions);
       questions.push({
         textKey: 'multiplyQuestion',
         a,
         b,
-        options: [String(mulResult - 1), String(mulResult), String(mulResult + 1), String(mulResult + 2)],
-        correctAnswer: 1,
+        options: mulOptions,
+        correctAnswer: mulOptions.indexOf(String(mulResult)),
         operation: 'multiply',
       });
 
       // Division (use a*b ÷ b = a)
       const dividend = a * b;
       const divResult = a;
+      const divOptions = [
+        String(divResult - 1),
+        String(divResult),
+        String(divResult + 1),
+        String(divResult + 2),
+      ];
+      shuffleArray(divOptions);
       questions.push({
         textKey: 'divideQuestion',
         a: dividend,
         b,
-        options: [String(divResult - 1), String(divResult), String(divResult + 1), String(divResult + 2)],
-        correctAnswer: 1,
+        options: divOptions,
+        correctAnswer: divOptions.indexOf(String(divResult)),
         operation: 'divide',
       });
     }
   }
 
-  return questions;
+  return shuffleArray(questions);
 }


### PR DESCRIPTION
## Summary
- shuffle options for each generated question
- return questions in random order
- adjust test to always pick an incorrect answer reliably

## Testing
- `npx jest` *(fails: jest could not be executed due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6872eb5a5f24832aa65ffb2678b8ffb7