### PR TITLE
Add badge to high scores

### DIFF
--- a/__tests__/HighScoreScreen.test.tsx
+++ b/__tests__/HighScoreScreen.test.tsx
@@ -7,10 +7,10 @@ import { setLocale, t } from '../src/i18n';
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
     Promise.resolve({
-      add: { score: 2, playerName: 'Bob', date: '2024-01-01' },
-      subtract: { score: 1, playerName: 'Alice', date: '2024-01-02' },
-      multiply: { score: 0, playerName: '', date: '' },
-      divide: { score: 0, playerName: '', date: '' },
+      add: { score: 2, playerName: 'Bob', date: '2024-01-01', badge: 'gold' },
+      subtract: { score: 1, playerName: 'Alice', date: '2024-01-02', badge: 'silver' },
+      multiply: { score: 0, playerName: '', date: '', badge: null },
+      divide: { score: 0, playerName: '', date: '', badge: null },
     })
   ),
 }));
@@ -24,7 +24,7 @@ describe('HighScoreScreen', () => {
         <HighScoreScreen navigation={{ goBack: jest.fn() } as any} route={{ key: 'h', name: 'HighScore' } as any} />
       </LanguageProvider>
     );
-    await findByText(`${t('addition')}: 2 (Bob 2024-01-01)`);
-    await findByText(`${t('subtraction')}: 1 (Alice 2024-01-02)`);
+    await findByText(`${t('addition')}: 2 (Bob 2024-01-01) - Gold Badge`);
+    await findByText(`${t('subtraction')}: 1 (Alice 2024-01-02) - Silver Badge`);
   });
 });

--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -7,10 +7,10 @@ import { setLocale, t } from '../src/i18n';
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
     Promise.resolve({
-      add: { score: 0, playerName: '', date: '' },
-      subtract: { score: 0, playerName: '', date: '' },
-      multiply: { score: 0, playerName: '', date: '' },
-      divide: { score: 0, playerName: '', date: '' },
+      add: { score: 0, playerName: '', date: '', badge: null },
+      subtract: { score: 0, playerName: '', date: '', badge: null },
+      multiply: { score: 0, playerName: '', date: '', badge: null },
+      divide: { score: 0, playerName: '', date: '', badge: null },
     })
   ),
 }));

--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -15,10 +15,10 @@ const TOTALS: OperationCount = questions.reduce<OperationCount>(
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
     Promise.resolve({
-      add: { score: 0, playerName: '', date: '' },
-      subtract: { score: 0, playerName: '', date: '' },
-      multiply: { score: 0, playerName: '', date: '' },
-      divide: { score: 0, playerName: '', date: '' },
+      add: { score: 0, playerName: '', date: '', badge: null },
+      subtract: { score: 0, playerName: '', date: '', badge: null },
+      multiply: { score: 0, playerName: '', date: '', badge: null },
+      divide: { score: 0, playerName: '', date: '', badge: null },
     })
   ),
   setHighScore: jest.fn(() => Promise.resolve()),

--- a/src/components/HighScoreScreen.tsx
+++ b/src/components/HighScoreScreen.tsx
@@ -6,21 +6,24 @@ import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 import { t } from '../i18n';
-import type { OperationRecordMap } from '../types/score';
+import type { OperationRecordMap, BadgeLevel } from '../types/score';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },
   card: { marginBottom: 16 },
 });
 
+const formatBadge = (badge: BadgeLevel): string =>
+  badge ? ` - ${badge.charAt(0).toUpperCase() + badge.slice(1)} Badge` : '';
+
 type Props = NativeStackScreenProps<RootStackParamList, 'HighScore'>;
 
 const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
   const [scores, setScores] = useState<OperationRecordMap>({
-    add: { score: 0, playerName: '', date: '' },
-    subtract: { score: 0, playerName: '', date: '' },
-    multiply: { score: 0, playerName: '', date: '' },
-    divide: { score: 0, playerName: '', date: '' },
+    add: { score: 0, playerName: '', date: '', badge: null },
+    subtract: { score: 0, playerName: '', date: '', badge: null },
+    multiply: { score: 0, playerName: '', date: '', badge: null },
+    divide: { score: 0, playerName: '', date: '', badge: null },
   });
 
   useEffect(() => {
@@ -33,16 +36,16 @@ const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
         <Card.Content>
           <Text variant="titleLarge">{t('highScores')}</Text>
           <Text>
-            {t('addition')}: {scores.add.score} ({scores.add.playerName} {scores.add.date})
+            {t('addition')}: {scores.add.score} ({scores.add.playerName} {scores.add.date}){formatBadge(scores.add.badge)}
           </Text>
           <Text>
-            {t('subtraction')}: {scores.subtract.score} ({scores.subtract.playerName} {scores.subtract.date})
+            {t('subtraction')}: {scores.subtract.score} ({scores.subtract.playerName} {scores.subtract.date}){formatBadge(scores.subtract.badge)}
           </Text>
           <Text>
-            {t('multiplication')}: {scores.multiply.score} ({scores.multiply.playerName} {scores.multiply.date})
+            {t('multiplication')}: {scores.multiply.score} ({scores.multiply.playerName} {scores.multiply.date}){formatBadge(scores.multiply.badge)}
           </Text>
           <Text>
-            {t('division')}: {scores.divide.score} ({scores.divide.playerName} {scores.divide.date})
+            {t('division')}: {scores.divide.score} ({scores.divide.playerName} {scores.divide.date}){formatBadge(scores.divide.badge)}
           </Text>
         </Card.Content>
       </Card>

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -6,7 +6,7 @@ import { Button, Card, Text } from 'react-native-paper';
 import { getHighScore, setHighScore } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { generateQuestions } from '../data/questions';
-import type { OperationCount, Operation, OperationRecordMap } from '../types/score';
+import type { OperationCount, Operation, OperationRecordMap, BadgeLevel } from '../types/score';
 import { t, type TranslationKey } from '../i18n';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
@@ -46,10 +46,17 @@ const QuizScreen = ({ navigation, route }: Props) => {
     let changed = false;
     (Object.keys(finalScores) as Operation[]).forEach((op) => {
       if (finalScores[op] > highScore[op].score) {
+        const total = finalTotals[op];
+        const pct = total ? finalScores[op] / total : 0;
+        let badge: BadgeLevel = null;
+        if (pct === 1) badge = 'gold';
+        else if (pct >= 0.8) badge = 'silver';
+        else if (pct >= 0.5) badge = 'bronze';
         updated[op] = {
           score: finalScores[op],
           playerName,
           date: new Date().toISOString(),
+          badge,
         };
         changed = true;
       }

--- a/src/storage/highScore.ts
+++ b/src/storage/highScore.ts
@@ -1,13 +1,13 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { OperationRecordMap } from '../types/score';
+import type { OperationRecordMap, Operation, OperationRecord } from '../types/score';
 
 const HIGH_SCORE_KEY = 'HIGH_SCORE';
 
 const DEFAULT_SCORES: OperationRecordMap = {
-  add: { score: 0, playerName: '', date: '' },
-  subtract: { score: 0, playerName: '', date: '' },
-  multiply: { score: 0, playerName: '', date: '' },
-  divide: { score: 0, playerName: '', date: '' },
+  add: { score: 0, playerName: '', date: '', badge: null },
+  subtract: { score: 0, playerName: '', date: '', badge: null },
+  multiply: { score: 0, playerName: '', date: '', badge: null },
+  divide: { score: 0, playerName: '', date: '', badge: null },
 };
 
 export const getHighScore = async (): Promise<OperationRecordMap> => {
@@ -16,7 +16,12 @@ export const getHighScore = async (): Promise<OperationRecordMap> => {
     return { ...DEFAULT_SCORES };
   }
   try {
-    return { ...DEFAULT_SCORES, ...JSON.parse(value) } as OperationRecordMap;
+    const parsed = JSON.parse(value) as Partial<OperationRecordMap>;
+    const result: OperationRecordMap = { ...DEFAULT_SCORES };
+    (Object.keys(DEFAULT_SCORES) as Operation[]).forEach((op) => {
+      result[op] = { ...DEFAULT_SCORES[op], ...(parsed[op] as Partial<OperationRecord>) };
+    });
+    return result;
   } catch {
     return { ...DEFAULT_SCORES };
   }

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -2,10 +2,13 @@ import type { Operation } from '../data/questions';
 
 export type OperationCount = Record<Operation, number>;
 
+export type BadgeLevel = 'gold' | 'silver' | 'bronze' | null;
+
 export type OperationRecord = {
   score: number;
   playerName: string;
   date: string;
+  badge: BadgeLevel;
 };
 
 export type OperationRecordMap = Record<Operation, OperationRecord>;


### PR DESCRIPTION
## Summary
- extend `OperationRecord` with `badge` property
- persist badge information in high score storage and calculation
- show badge levels on HighScoreScreen
- adjust tests for new badge field

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872ec8115d8832aa28d96afb1d65bb4