### PR TITLE
Enable random question and answer order

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -6,7 +6,7 @@ import type { OperationCount } from '../src/types/score';
 import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale } from '../src/i18n';
 
-const questions = generateQuestions();
+const questions = generateQuestions({ shuffleQuestions: false, shuffleOptions: false });
 const TOTALS: OperationCount = questions.reduce<OperationCount>(
   (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
   { add: 0, subtract: 0, multiply: 0, divide: 0 }
@@ -31,7 +31,7 @@ describe('QuizScreen', () => {
     setLocale('en');
     const { getByText } = render(
       <LanguageProvider>
-        <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz', params: { playerName: 'Bob' } } as any} />
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '1', name: 'Quiz', params: { playerName: 'Bob', questions } } as any} />
       </LanguageProvider>
     );
 
@@ -57,7 +57,7 @@ describe('QuizScreen', () => {
     setLocale('en');
     const { getByText } = render(
       <LanguageProvider>
-        <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz', params: { playerName: 'Bob' } } as any} />
+        <QuizScreen navigation={{ navigate } as any} route={{ key: '2', name: 'Quiz', params: { playerName: 'Bob', questions } } as any} />
       </LanguageProvider>
     );
 

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -6,7 +6,7 @@ import type { OperationCount } from '../src/types/score';
 import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale } from '../src/i18n';
 
-const questions = generateQuestions();
+const questions = generateQuestions({ shuffleQuestions: false, shuffleOptions: false });
 const TOTALS: OperationCount = questions.reduce<OperationCount>(
   (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
   { add: 0, subtract: 0, multiply: 0, divide: 0 }

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -12,7 +12,12 @@ import { t, type TranslationKey } from '../i18n';
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
 
 const QuizScreen = ({ navigation, route }: Props) => {
-  const allQuestions = useMemo(() => generateQuestions(), []);
+  const allQuestions = useMemo(() => {
+    if (route.params?.questions) {
+      return route.params.questions;
+    }
+    return generateQuestions();
+  }, [route.params?.questions]);
   const { playerName } = route.params;
   const selectedOp = route.params?.operation ?? 'all';
   const activeQuestions =

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -9,59 +9,103 @@ export type MathQuestion = {
   operation: Operation;
 };
 
-export function generateQuestions(): MathQuestion[] {
+import { shuffleArray } from '../utils/shuffle';
+
+export type GenerateOptions = {
+  shuffleQuestions?: boolean;
+  shuffleOptions?: boolean;
+};
+
+export function generateQuestions(options?: GenerateOptions): MathQuestion[] {
+  const { shuffleQuestions = true, shuffleOptions = true } = options || {};
   const questions: MathQuestion[] = [];
 
   for (let a = 1; a <= 10; a++) {
     for (let b = 1; b <= 10; b++) {
       // Addition
       const addResult = a + b;
-      questions.push({
-        textKey: 'addQuestion',
-        a,
-        b,
-        options: [String(addResult - 1), String(addResult), String(addResult + 1), String(addResult + 2)],
-        correctAnswer: 1,
-        operation: 'add',
-      });
+      {
+        const opts = [
+          String(addResult - 1),
+          String(addResult),
+          String(addResult + 1),
+          String(addResult + 2),
+        ];
+        const optionsArr = shuffleOptions ? shuffleArray(opts) : opts;
+        questions.push({
+          textKey: 'addQuestion',
+          a,
+          b,
+          options: optionsArr,
+          correctAnswer: optionsArr.indexOf(String(addResult)),
+          operation: 'add',
+        });
+      }
 
       // Subtraction (ensure non-negative by making minuend >= subtrahend)
       const minuend = a >= b ? a : b;
       const subtrahend = a >= b ? b : a;
       const subResult = minuend - subtrahend;
-      questions.push({
-        textKey: 'subtractQuestion',
-        a: minuend,
-        b: subtrahend,
-        options: [String(subResult - 1), String(subResult), String(subResult + 1), String(subResult + 2)],
-        correctAnswer: 1,
-        operation: 'subtract',
-      });
+      {
+        const opts = [
+          String(subResult - 1),
+          String(subResult),
+          String(subResult + 1),
+          String(subResult + 2),
+        ];
+        const optionsArr = shuffleOptions ? shuffleArray(opts) : opts;
+        questions.push({
+          textKey: 'subtractQuestion',
+          a: minuend,
+          b: subtrahend,
+          options: optionsArr,
+          correctAnswer: optionsArr.indexOf(String(subResult)),
+          operation: 'subtract',
+        });
+      }
 
       // Multiplication
       const mulResult = a * b;
-      questions.push({
-        textKey: 'multiplyQuestion',
-        a,
-        b,
-        options: [String(mulResult - 1), String(mulResult), String(mulResult + 1), String(mulResult + 2)],
-        correctAnswer: 1,
-        operation: 'multiply',
-      });
+      {
+        const opts = [
+          String(mulResult - 1),
+          String(mulResult),
+          String(mulResult + 1),
+          String(mulResult + 2),
+        ];
+        const optionsArr = shuffleOptions ? shuffleArray(opts) : opts;
+        questions.push({
+          textKey: 'multiplyQuestion',
+          a,
+          b,
+          options: optionsArr,
+          correctAnswer: optionsArr.indexOf(String(mulResult)),
+          operation: 'multiply',
+        });
+      }
 
       // Division (use a*b ÷ b = a)
       const dividend = a * b;
       const divResult = a;
-      questions.push({
-        textKey: 'divideQuestion',
-        a: dividend,
-        b,
-        options: [String(divResult - 1), String(divResult), String(divResult + 1), String(divResult + 2)],
-        correctAnswer: 1,
-        operation: 'divide',
-      });
+      {
+        const opts = [
+          String(divResult - 1),
+          String(divResult),
+          String(divResult + 1),
+          String(divResult + 2),
+        ];
+        const optionsArr = shuffleOptions ? shuffleArray(opts) : opts;
+        questions.push({
+          textKey: 'divideQuestion',
+          a: dividend,
+          b,
+          options: optionsArr,
+          correctAnswer: optionsArr.indexOf(String(divResult)),
+          operation: 'divide',
+        });
+      }
     }
   }
 
-  return questions;
+  return shuffleQuestions ? shuffleArray(questions) : questions;
 }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -5,6 +5,7 @@ export type RootStackParamList = {
   Quiz: {
     operation?: import('./score').Operation | 'all';
     playerName: string;
+    questions?: import('../data/questions').MathQuestion[];
   };
   Result: {
     scores: import('./score').OperationCount;

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export function shuffleArray<T>(array: T[], rand: () => number = Math.random): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}


### PR DESCRIPTION
## Summary
- randomize answer options and overall question order
- allow passing custom question list to QuizScreen for testing
- update navigation types accordingly
- adjust tests to inject questions directly

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6872e59e1004832a9cc2f857be1a54fa