### PR TITLE
Add round summary screen

### DIFF
--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -39,6 +39,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
   });
   const [mistakes, setMistakes] = useState(0);
   const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
+  const [cycleResults, setCycleResults] = useState<boolean[]>([]);
 
   const finishQuiz = async (finalScores: OperationCount, finalTotals: OperationCount) => {
     const highScore = await getHighScore();
@@ -87,6 +88,14 @@ const QuizScreen = ({ navigation, route }: Props) => {
       setMistakes((m) => m + 1);
     }
 
+    setCycleResults((prev) => [...prev, isCorrect]);
+
+    const updatedScore = isCorrect ? score + 1 : score;
+    const updatedScoreByOp = isCorrect
+      ? { ...scoreByOp, [op]: scoreByOp[op] + 1 }
+      : scoreByOp;
+    const updatedTotals = { ...totals, [op]: totals[op] + 1 };
+
     const next = current + 1;
     if (next < QUESTIONS_PER_CYCLE && questionIndex + 1 < activeQuestions.length) {
       setCurrent(next);
@@ -94,21 +103,34 @@ const QuizScreen = ({ navigation, route }: Props) => {
     }
 
     // Cycle finished
+    const roundQuestions = activeQuestions.slice(
+      cycle * QUESTIONS_PER_CYCLE,
+      cycle * QUESTIONS_PER_CYCLE + QUESTIONS_PER_CYCLE
+    );
+    const results = [...cycleResults, isCorrect];
+
     if (mistakes + (isCorrect ? 0 : 1) > 0) {
-      await finishQuiz(
-        isCorrect ? { ...scoreByOp, [op]: scoreByOp[op] + 1 } : scoreByOp,
-        { ...totals, [op]: totals[op] + 1 }
-      );
+      navigation.navigate('RoundSummary', {
+        questions: roundQuestions,
+        results,
+        allCorrect: false,
+        playerName,
+        score: updatedScore,
+      });
     } else if (cycle + 1 < totalCycles) {
-      // next cycle
       setCycle(cycle + 1);
       setCurrent(0);
       setMistakes(0);
+      setCycleResults([]);
+      navigation.navigate('RoundSummary', {
+        questions: roundQuestions,
+        results,
+        allCorrect: true,
+        playerName,
+        score: updatedScore,
+      });
     } else {
-      await finishQuiz(
-        isCorrect ? { ...scoreByOp, [op]: scoreByOp[op] + 1 } : scoreByOp,
-        { ...totals, [op]: totals[op] + 1 }
-      );
+      await finishQuiz(updatedScoreByOp, updatedTotals);
     }
   };
 

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -1,0 +1,79 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Card, Text } from 'react-native-paper';
+import { RootStackParamList } from '../types/navigation';
+import type { MathQuestion } from '../data/questions';
+import { t, type TranslationKey } from '../i18n';
+import { useLanguage } from '../i18n/LanguageContext';
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  card: { marginBottom: 16 },
+  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 4 },
+  question: { flex: 1 },
+  result: { fontSize: 20, marginLeft: 8 },
+  correct: { color: '#4caf50' },
+  wrong: { color: '#f44336' },
+  button: { marginTop: 8 },
+});
+
+type Props = NativeStackScreenProps<RootStackParamList, 'RoundSummary'>;
+
+const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
+  const { questions, results, allCorrect, playerName, score } = route.params;
+  useLanguage();
+
+  const renderRow = (q: MathQuestion, idx: number) => (
+    <View key={idx} style={styles.row}>
+      <Text style={styles.question}>
+        {t(q.textKey as TranslationKey, { a: q.a, b: q.b })}
+      </Text>
+      <Text
+        style={[
+          styles.result,
+          results[idx] ? styles.correct : styles.wrong,
+        ]}
+      >
+        {results[idx] ? '✔' : '✘'}
+      </Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Card style={styles.card} elevation={2}>
+        <Card.Content>
+          <Text variant="titleLarge">{t('roundSummary')}</Text>
+          {questions.map(renderRow)}
+        </Card.Content>
+      </Card>
+      {allCorrect ? (
+        <>
+          <Button mode="contained" onPress={() => navigation.goBack()} style={styles.button}>
+            {t('continue')}
+          </Button>
+          <Button
+            mode="contained"
+            onPress={() => navigation.navigate('Home')}
+            style={styles.button}
+          >
+            {t('goHome')}
+          </Button>
+        </>
+      ) : (
+        <Button
+          mode="contained"
+          onPress={() =>
+            navigation.replace('Selection', { playerName, score })
+          }
+        >
+          {t('backToSelection')}
+        </Button>
+      )}
+    </SafeAreaView>
+  );
+};
+
+export default RoundSummaryScreen;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -31,5 +31,7 @@
   "viewRecords": "Rekorde ansehen",
   "highScores": "Rekorde",
   "enterName": "Gib deinen Namen ein"
+  ,"roundSummary": "Rundenübersicht"
+  ,"backToSelection": "Zur Auswahl zurück"
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,5 +31,7 @@
   "viewRecords": "View Records",
   "highScores": "High Scores",
   "enterName": "Enter your name"
+  ,"roundSummary": "Round Summary"
+  ,"backToSelection": "Back to Selection"
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -31,5 +31,7 @@
   "viewRecords": "Ver récords",
   "highScores": "Récords",
   "enterName": "Ingresa tu nombre"
+  ,"roundSummary": "Resumen de ronda"
+  ,"backToSelection": "Volver a selección"
 }
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -7,6 +7,7 @@ import SelectionScreen from '../components/SelectionScreen';
 import HighScoreScreen from '../components/HighScoreScreen';
 import QuizScreen from '../components/QuizScreen';
 import ResultScreen from '../components/ResultScreen';
+import RoundSummaryScreen from '../components/RoundSummaryScreen';
 
 import type { RootStackParamList } from '../types/navigation';
 
@@ -21,6 +22,7 @@ export default function AppNavigator() {
         <Stack.Screen name="Quiz" component={QuizScreen} />
         <Stack.Screen name="HighScore" component={HighScoreScreen} />
         <Stack.Screen name="Result" component={ResultScreen} />
+        <Stack.Screen name="RoundSummary" component={RoundSummaryScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,6 +1,6 @@
 export type RootStackParamList = {
   Home: undefined;
-  Selection: { playerName: string };
+  Selection: { playerName: string; score?: number };
   HighScore: undefined;
   Quiz: {
     operation?: import('./score').Operation | 'all';
@@ -9,5 +9,12 @@ export type RootStackParamList = {
   Result: {
     scores: import('./score').OperationCount;
     totals: import('./score').OperationCount;
+  };
+  RoundSummary: {
+    questions: import('../data/questions').MathQuestion[];
+    results: boolean[];
+    allCorrect: boolean;
+    playerName: string;
+    score: number;
   };
 };


### PR DESCRIPTION
## Summary
- add a RoundSummaryScreen component showing question results
- navigate to this screen from QuizScreen after each cycle
- extend navigation types and stack
- include translations for new labels

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68738776d300832aa7b91afc04cbfb90