### PR TITLE
Refresh high scores on screen focus

### DIFF
--- a/__tests__/HighScoreScreen.test.tsx
+++ b/__tests__/HighScoreScreen.test.tsx
@@ -4,6 +4,14 @@ import HighScoreScreen from '../src/components/HighScoreScreen';
 import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale, t } from '../src/i18n';
 
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
 jest.mock('../src/storage/highScore', () => ({
   getHighScore: jest.fn(() =>
     Promise.resolve({

--- a/src/components/HighScoreScreen.tsx
+++ b/src/components/HighScoreScreen.tsx
@@ -1,5 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
@@ -26,9 +27,11 @@ const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
     divide: { score: 0, playerName: '', date: '', badge: null },
   });
 
-  useEffect(() => {
-    getHighScore().then(setScores);
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      getHighScore().then(setScores);
+    }, [])
+  );
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Summary
- use `useFocusEffect` in `HighScoreScreen` to reload records each time the screen becomes active
- update HighScoreScreen unit test to mock `useFocusEffect`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687388fcf434832a9ed094b81fec567a