### PR TITLE
Add round score label

### DIFF
--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -16,6 +16,7 @@ const styles = StyleSheet.create({
   result: { fontSize: 20, marginLeft: 8 },
   correct: { color: '#4caf50' },
   wrong: { color: '#f44336' },
+  score: { textAlign: 'center', marginBottom: 8 },
   button: { marginTop: 8 },
 });
 
@@ -49,6 +50,9 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
           {questions.map(renderRow)}
         </Card.Content>
       </Card>
+      <Text variant="titleMedium" style={styles.score}>
+        {t('roundScore', { score, total: questions.length })}
+      </Text>
       {allCorrect ? (
         <>
           <Button mode="contained" onPress={() => navigation.goBack()} style={styles.button}>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -5,6 +5,7 @@
   "none": "Keine",
   "continue": "Weiter",
   "yourScore": "Dein Ergebnis: {{score}} / {{total}}",
+  "roundScore": "{{score}} / {{total}}",
   "goHome": "Zurück zur Startseite",
   "badgesEarned": "Verdiente Abzeichen:",
   "addition": "Addition",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -5,6 +5,7 @@
   "none": "None",
   "continue": "Continue",
   "yourScore": "Your Score: {{score}} / {{total}}",
+  "roundScore": "{{score}} / {{total}}",
   "goHome": "Go back to Home",
   "badgesEarned": "Badges Earned:",
   "addition": "Addition",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -5,6 +5,7 @@
   "none": "Ninguna",
   "continue": "Continuar",
   "yourScore": "Tu puntuación: {{score}} / {{total}}",
+  "roundScore": "{{score}} / {{total}}",
   "goHome": "Volver al inicio",
   "badgesEarned": "Insignias obtenidas:",
   "addition": "Adición",


### PR DESCRIPTION
## Summary
- show a score label on the round summary screen
- add new `roundScore` translation key for de, en and es

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a6e72b3c832aaba159fe26a53c6e