### PR TITLE
Record scores when cycle fails

### DIFF
--- a/__tests__/RoundSummaryScreen.test.tsx
+++ b/__tests__/RoundSummaryScreen.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import RoundSummaryScreen from '../src/components/RoundSummaryScreen';
+import { LanguageProvider } from '../src/i18n/LanguageContext';
+import { setLocale, t } from '../src/i18n';
+import { generateQuestions } from '../src/data/questions';
+
+jest.mock('../src/storage/highScore', () => ({
+  updateHighScoreIfNeeded: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useFocusEffect: (cb: () => void) => cb(),
+  };
+});
+
+const question = generateQuestions()[0];
+
+describe('RoundSummaryScreen', () => {
+  beforeEach(() => setLocale('en'));
+
+  it('updates high score when returning to selection', async () => {
+    const replace = jest.fn();
+    const { getByText } = render(
+      <LanguageProvider>
+        <RoundSummaryScreen
+          navigation={{ replace } as any}
+          route={{
+            key: 'r',
+            name: 'RoundSummary',
+            params: {
+              questions: [question],
+              results: [false],
+              allCorrect: false,
+              playerName: 'Bob',
+              score: 1,
+              totals: { add: 1, subtract: 0, multiply: 0, divide: 0 },
+              scores: { add: 0, subtract: 0, multiply: 0, divide: 0 },
+            },
+          } as any}
+        />
+      </LanguageProvider>
+    );
+
+    fireEvent.press(getByText(t('backToSelection')));
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('Selection', { playerName: 'Bob', score: 1 })
+    );
+    const { updateHighScoreIfNeeded } = require('../src/storage/highScore');
+    expect(updateHighScoreIfNeeded).toHaveBeenCalledWith(
+      { add: 0, subtract: 0, multiply: 0, divide: 0 },
+      { add: 1, subtract: 0, multiply: 0, divide: 0 },
+      'Bob'
+    );
+  });
+});

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -3,10 +3,10 @@ import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
-import { getHighScore, setHighScore } from '../storage/highScore';
+import { updateHighScoreIfNeeded } from '../storage/highScore';
 import { RootStackParamList } from '../types/navigation';
 import { generateQuestions } from '../data/questions';
-import type { OperationCount, Operation, OperationRecordMap, BadgeLevel } from '../types/score';
+import type { OperationCount, Operation } from '../types/score';
 import { t, type TranslationKey } from '../i18n';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Quiz'>;
@@ -50,30 +50,11 @@ const QuizScreen = ({ navigation, route }: Props) => {
     };
   }, []);
 
-  const finishQuiz = async (finalScores: OperationCount, finalTotals: OperationCount) => {
-    const highScore = await getHighScore();
-    const updated: OperationRecordMap = { ...highScore };
-    let changed = false;
-    (Object.keys(finalScores) as Operation[]).forEach((op) => {
-      if (finalScores[op] > highScore[op].score) {
-        const total = finalTotals[op];
-        const pct = total ? finalScores[op] / total : 0;
-        let badge: BadgeLevel = null;
-        if (pct === 1) badge = 'gold';
-        else if (pct >= 0.8) badge = 'silver';
-        else if (pct >= 0.5) badge = 'bronze';
-        updated[op] = {
-          score: finalScores[op],
-          playerName,
-          date: new Date().toISOString(),
-          badge,
-        };
-        changed = true;
-      }
-    });
-    if (changed) {
-      await setHighScore(updated);
-    }
+  const finishQuiz = async (
+    finalScores: OperationCount,
+    finalTotals: OperationCount
+  ) => {
+    await updateHighScoreIfNeeded(finalScores, finalTotals, playerName);
     navigation.navigate('Result', {
       scores: finalScores,
       totals: finalTotals,
@@ -128,6 +109,8 @@ const QuizScreen = ({ navigation, route }: Props) => {
         allCorrect: false,
         playerName,
         score: updatedScore,
+        totals: updatedTotals,
+        scores: updatedScoreByOp,
       });
     } else if (cycle + 1 < totalCycles) {
       setCycle(cycle + 1);

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View, Dimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
+import { updateHighScoreIfNeeded } from '../storage/highScore';
 import type { MathQuestion } from '../data/questions';
 import { t, type TranslationKey } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
@@ -24,7 +25,8 @@ const styles = StyleSheet.create({
 type Props = NativeStackScreenProps<RootStackParamList, 'RoundSummary'>;
 
 const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
-  const { questions, results, allCorrect, playerName, score } = route.params;
+  const { questions, results, allCorrect, playerName, score, totals, scores } =
+    route.params;
   useLanguage();
 
   const { width } = Dimensions.get('window');
@@ -90,9 +92,12 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
       ) : (
         <Button
           mode="contained"
-          onPress={() =>
-            navigation.replace('Selection', { playerName, score })
-          }
+          onPress={async () => {
+            if (totals && scores) {
+              await updateHighScoreIfNeeded(scores, totals, playerName);
+            }
+            navigation.replace('Selection', { playerName, score });
+          }}
         >
           {t('backToSelection')}
         </Button>

--- a/src/storage/highScore.ts
+++ b/src/storage/highScore.ts
@@ -1,5 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import type { OperationRecordMap, Operation, OperationRecord } from '../types/score';
+import type {
+  OperationRecordMap,
+  Operation,
+  OperationRecord,
+  OperationCount,
+  BadgeLevel,
+} from '../types/score';
 
 const HIGH_SCORE_KEY = 'HIGH_SCORE';
 
@@ -29,4 +35,34 @@ export const getHighScore = async (): Promise<OperationRecordMap> => {
 
 export const setHighScore = async (scores: OperationRecordMap): Promise<void> => {
   await AsyncStorage.setItem(HIGH_SCORE_KEY, JSON.stringify(scores));
+};
+
+export const updateHighScoreIfNeeded = async (
+  scores: OperationCount,
+  totals: OperationCount,
+  playerName: string
+): Promise<void> => {
+  const highScore = await getHighScore();
+  const updated: OperationRecordMap = { ...highScore };
+  let changed = false;
+  (Object.keys(scores) as Operation[]).forEach((op) => {
+    if (scores[op] > highScore[op].score) {
+      const total = totals[op];
+      const pct = total ? scores[op] / total : 0;
+      let badge: BadgeLevel = null;
+      if (pct === 1) badge = 'gold';
+      else if (pct >= 0.8) badge = 'silver';
+      else if (pct >= 0.5) badge = 'bronze';
+      updated[op] = {
+        score: scores[op],
+        playerName,
+        date: new Date().toISOString(),
+        badge,
+      };
+      changed = true;
+    }
+  });
+  if (changed) {
+    await setHighScore(updated);
+  }
 };

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -16,5 +16,7 @@ export type RootStackParamList = {
     allCorrect: boolean;
     playerName: string;
     score: number;
+    totals?: import('./score').OperationCount;
+    scores?: import('./score').OperationCount;
   };
 };


### PR DESCRIPTION
## Summary
- add `updateHighScoreIfNeeded` helper to handle record updates
- use helper inside `QuizScreen` and pass scores/totals to `RoundSummaryScreen`
- update `RoundSummaryScreen` to store scores on exit
- extend navigation types and add tests for summary screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a8d11260832a86c70ce0873d6dab