### PR TITLE
Fix QuizScreen cycle failure test

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -74,10 +74,19 @@ describe('QuizScreen', () => {
       fireEvent.press(getByText(questions[i].options[questions[i].correctAnswer]));
     }
 
+    const roundQuestions = questions.slice(0, 10);
+    const results = [false, ...Array(9).fill(true)];
+    const score = Object.values(cycleScores).reduce((a, b) => a + b, 0);
+
     await waitFor(() =>
-      expect(navigate).toHaveBeenCalledWith('Result', {
-        scores: cycleScores,
+      expect(navigate).toHaveBeenCalledWith('RoundSummary', {
+        questions: roundQuestions,
+        results,
+        allCorrect: false,
+        playerName: 'Bob',
+        score,
         totals: cycleTotals,
+        scores: cycleScores,
       })
     );
   });


### PR DESCRIPTION
## Summary
- update QuizScreen test to expect navigation to `RoundSummary` when a mistake ends the cycle

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873aaa4bbe4832aa65d439b0e3cfec3