### PR TITLE
Add score display on selection screen

### DIFF
--- a/__tests__/SelectionScreen.test.tsx
+++ b/__tests__/SelectionScreen.test.tsx
@@ -36,4 +36,17 @@ describe('SelectionScreen', () => {
     fireEvent.press(getByText(t('viewRecords')));
     expect(navigate).toHaveBeenCalledWith('HighScore');
   });
+
+  it('shows current score when provided', () => {
+    const { getByText } = render(
+      <LanguageProvider>
+        <SelectionScreen
+          navigation={{} as any}
+          route={{ key: '3', name: 'Selection', params: { playerName: 'Bob', score: 3 } } as any}
+        />
+      </LanguageProvider>
+    );
+
+    expect(getByText(t('currentScore', { score: 3, total: 10 }))).toBeTruthy();
+  });
 });

--- a/src/components/SelectionScreen.tsx
+++ b/src/components/SelectionScreen.tsx
@@ -16,12 +16,17 @@ const styles = StyleSheet.create({
 type Props = NativeStackScreenProps<RootStackParamList, 'Selection'>;
 
 const SelectionScreen: React.FC<Props> = ({ navigation, route }) => {
-  const { playerName } = route.params;
+  const { playerName, score } = route.params;
   return (
     <SafeAreaView style={styles.container}>
       <Text variant="titleLarge" style={styles.title}>
         {t('selectOperation')}
       </Text>
+      {typeof score === 'number' && (
+        <Text variant="titleMedium" style={styles.title}>
+          {t('currentScore', { score, total: 10 })}
+        </Text>
+      )}
       <Button
         mode="contained"
         onPress={() => navigation.navigate('Quiz', { operation: 'add', playerName })}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -34,5 +34,6 @@
   "enterName": "Gib deinen Namen ein"
   ,"roundSummary": "Rundenübersicht"
   ,"backToSelection": "Zur Auswahl zurück"
+  ,"currentScore": "Aktueller Punktestand: {{score}} / {{total}}"
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,5 +34,6 @@
   "enterName": "Enter your name"
   ,"roundSummary": "Round Summary"
   ,"backToSelection": "Back to Selection"
+  ,"currentScore": "Current score: {{score}} / {{total}}"
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -34,5 +34,6 @@
   "enterName": "Ingresa tu nombre"
   ,"roundSummary": "Resumen de ronda"
   ,"backToSelection": "Volver a selección"
+  ,"currentScore": "Puntuación actual: {{score}} / {{total}}"
 }
 


### PR DESCRIPTION
## Summary
- show current score when returning to selection
- translate `currentScore` string in all languages
- test rendering of the score message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ab7c71f0832aa64c799b349cd947