### PR TITLE
Switch to lottie-react

### DIFF
--- a/__tests__/RoundSummaryScreen.test.tsx
+++ b/__tests__/RoundSummaryScreen.test.tsx
@@ -5,7 +5,7 @@ import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale, t } from '../src/i18n';
 import { generateQuestions } from '../src/data/questions';
 
-jest.mock('lottie-react-native', () => 'LottieView');
+jest.mock('lottie-react', () => 'Lottie');
 
 jest.mock('../src/storage/highScore', () => ({
   updateHighScoreIfNeeded: jest.fn(() => Promise.resolve()),

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "lottie-react-native": "^6.2.0"
+    "lottie-react": "^2.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -8,7 +8,7 @@ import { updateHighScoreIfNeeded } from '../storage/highScore';
 import type { MathQuestion } from '../data/questions';
 import { t, type TranslationKey } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
-import LottieView from 'lottie-react-native';
+import Lottie from 'lottie-react';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },
@@ -55,8 +55,8 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
   return (
     <SafeAreaView style={styles.container}>
       {showAnimation && (
-        <LottieView
-          source={
+        <Lottie
+          animationData={
             allCorrect
               ? require('../../assets/lottie/success.json')
               : require('../../assets/lottie/failure.json')


### PR DESCRIPTION
## Summary
- add `lottie-react` dependency and remove `lottie-react-native`
- update `RoundSummaryScreen` to use `lottie-react`
- update unit tests to mock `lottie-react`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ce6af038832a92adcbc8db8bde1b