### PR TITLE
Update home button to back to selection

### DIFF
--- a/__tests__/RoundSummaryScreen.test.tsx
+++ b/__tests__/RoundSummaryScreen.test.tsx
@@ -58,4 +58,31 @@ describe('RoundSummaryScreen', () => {
       'Bob'
     );
   });
+
+  it('allows navigating back to selection after a perfect round', async () => {
+    const replace = jest.fn();
+    const { getByText } = render(
+      <LanguageProvider>
+        <RoundSummaryScreen
+          navigation={{ replace } as any}
+          route={{
+            key: 'r2',
+            name: 'RoundSummary',
+            params: {
+              questions: [question],
+              results: [true],
+              allCorrect: true,
+              playerName: 'Bob',
+              score: 1,
+            },
+          } as any}
+        />
+      </LanguageProvider>
+    );
+
+    fireEvent.press(getByText(t('backToSelection')));
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('Selection', { playerName: 'Bob', score: 1 })
+    );
+  });
 });

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -82,10 +82,10 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
           </Button>
           <Button
             mode="contained"
-            onPress={() => navigation.navigate('Home')}
+            onPress={() => navigation.replace('Selection', { playerName, score })}
             style={styles.button}
           >
-            {t('goHome')}
+            {t('backToSelection')}
           </Button>
         </>
       ) : (


### PR DESCRIPTION
## Summary
- change the Go Home button to use backToSelection logic
- test returning to selection after a perfect round

## Testing
- `npx jest` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873f60d4b84832a8510920b24df41f3