### PR TITLE
Add playerName navigation to Result

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -43,6 +43,7 @@ describe('QuizScreen', () => {
       expect(navigate).toHaveBeenCalledWith('Result', {
         scores: TOTALS,
         totals: TOTALS,
+        playerName: 'Bob',
       })
     );
     const { setHighScore } = require('../src/storage/highScore');

--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -14,12 +14,20 @@ const TOTALS: OperationCount = questions.reduce<OperationCount>(
 
 const PERFECT: OperationCount = { ...TOTALS };
 
-const renderScreen = (scores: OperationCount, totals: OperationCount = TOTALS) =>
+const renderScreen = (
+  scores: OperationCount,
+  totals: OperationCount = TOTALS,
+  playerName = 'Bob'
+) =>
   render(
     <LanguageProvider>
       <ResultScreen
         navigation={{ navigate: jest.fn() } as any}
-        route={{ key: 'result', name: 'Result', params: { scores, totals } } as any }
+        route={{
+          key: 'result',
+          name: 'Result',
+          params: { scores, totals, playerName },
+        } as any}
       />
     </LanguageProvider>
   );

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -58,6 +58,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
     navigation.navigate('Result', {
       scores: finalScores,
       totals: finalTotals,
+      playerName,
     });
   };
   const handleAnswer = async (index: number) => {

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -12,7 +12,7 @@ import { useLanguage } from '../i18n/LanguageContext';
 type Props = NativeStackScreenProps<RootStackParamList, 'Result'>;
 
 export default function ResultScreen({ navigation, route }: Props) {
-  const { scores, totals } = route.params;
+  const { scores, totals, playerName } = route.params;
   useLanguage();
 
   const operationNames: Record<Operation, string> = {
@@ -63,8 +63,8 @@ export default function ResultScreen({ navigation, route }: Props) {
           <BadgeDisplay badges={badges} />
         </Card.Content>
       </Card>
-      <Button mode="contained" onPress={() => navigation.navigate('Home')}>
-        {t('goHome')}
+      <Button onPress={() => navigation.navigate('Selection', { playerName })}>
+        {t('backToSelection')}
       </Button>
     </SafeAreaView>
   );

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -9,6 +9,7 @@ export type RootStackParamList = {
   Result: {
     scores: import('./score').OperationCount;
     totals: import('./score').OperationCount;
+    playerName: string;
   };
   RoundSummary: {
     questions: import('../data/questions').MathQuestion[];


### PR DESCRIPTION
## Summary
- add playerName param to `RootStackParamList` Result route
- forward the name when finishing the quiz
- show back-to-selection button on result screen and use the name
- update tests for new navigation params

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f6a7ada0832a8b28d59bccf73a13