### PR TITLE
Add medal board

### DIFF
--- a/src/components/MedalBoardScreen.tsx
+++ b/src/components/MedalBoardScreen.tsx
@@ -1,0 +1,66 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Card, Text } from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import { RootStackParamList } from '../types/navigation';
+import { getMedalBoard } from '../storage/medalBoard';
+import type { MedalBoardMap, BadgeLevel } from '../types/score';
+import { t } from '../i18n';
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  card: { marginBottom: 16 },
+});
+
+const formatBadge = (badge: BadgeLevel): string =>
+  badge ? ` - ${badge.charAt(0).toUpperCase() + badge.slice(1)} Medal` : '';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MedalBoard'>;
+
+const MedalBoardScreen: React.FC<Props> = ({ navigation }) => {
+  const [board, setBoard] = useState<MedalBoardMap>({
+    add: [],
+    subtract: [],
+    multiply: [],
+    divide: [],
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      getMedalBoard().then(setBoard);
+    }, [])
+  );
+
+  const renderList = (op: keyof MedalBoardMap, title: string) => (
+    <>
+      <Text variant="titleMedium">{title}</Text>
+      {board[op].length === 0 && <Text>{t('none')}</Text>}
+      {board[op].map((rec, idx) => (
+        <Text key={idx}>
+          {idx === 0 ? t('gold') : idx === 1 ? t('silver') : t('bronze')}: {rec.score} ({rec.playerName} {rec.date}){formatBadge(rec.badge)}
+        </Text>
+      ))}
+    </>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Card style={styles.card} elevation={2}>
+        <Card.Content>
+          <Text variant="titleLarge">{t('medalBoard')}</Text>
+          {renderList('add', t('addition'))}
+          {renderList('subtract', t('subtraction'))}
+          {renderList('multiply', t('multiplication'))}
+          {renderList('divide', t('division'))}
+        </Card.Content>
+      </Card>
+      <Button mode="contained" onPress={() => navigation.goBack()}>
+        {t('goHome')}
+      </Button>
+    </SafeAreaView>
+  );
+};
+
+export default MedalBoardScreen;

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
 import { updateHighScoreIfNeeded } from '../storage/highScore';
+import { updateMedalBoard } from '../storage/medalBoard';
 import { RootStackParamList } from '../types/navigation';
 import { generateQuestions } from '../data/questions';
 import type { OperationCount, Operation } from '../types/score';
@@ -55,6 +56,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
     finalTotals: OperationCount
   ) => {
     await updateHighScoreIfNeeded(finalScores, finalTotals, playerName);
+    await updateMedalBoard(finalScores, finalTotals, playerName);
     navigation.navigate('Result', {
       scores: finalScores,
       totals: finalTotals,

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
 import { RootStackParamList } from '../types/navigation';
 import { updateHighScoreIfNeeded } from '../storage/highScore';
+import { updateMedalBoard } from '../storage/medalBoard';
 import type { MathQuestion } from '../data/questions';
 import { t, type TranslationKey } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
@@ -94,6 +95,7 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
           onPress={async () => {
             if (totals && scores) {
               await updateHighScoreIfNeeded(scores, totals, playerName);
+              await updateMedalBoard(scores, totals, playerName);
             }
             navigation.replace('Selection', { playerName, score });
           }}

--- a/src/components/SelectionScreen.tsx
+++ b/src/components/SelectionScreen.tsx
@@ -64,6 +64,16 @@ const SelectionScreen: React.FC<Props> = ({ navigation, route }) => {
       >
         {t('viewRecords')}
       </Button>
+      <Button
+        mode="outlined"
+        style={styles.button}
+        onPress={() => navigation.navigate('MedalBoard')}
+        icon={({ size, color }) => (
+          <MaterialCommunityIcons name="medal" size={size} color={color} />
+        )}
+      >
+        {t('viewMedals')}
+      </Button>
     </SafeAreaView>
   );
 };

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -30,8 +30,13 @@
   "operation_all": "Alle",
   "selectOperation": "Operation wählen",
   "viewRecords": "Rekorde ansehen",
+  "viewMedals": "Medaillen ansehen",
   "highScores": "Rekorde",
-  "enterName": "Gib deinen Namen ein"
+  "enterName": "Gib deinen Namen ein",
+  "medalBoard": "Medaillenrangliste",
+  "gold": "Gold",
+  "silver": "Silber",
+  "bronze": "Bronze"
   ,"roundSummary": "Rundenübersicht"
   ,"backToSelection": "Zur Auswahl zurück"
   ,"currentScore": "Aktueller Punktestand: {{score}} / {{total}}"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,8 +30,13 @@
   "divideQuestion": "What is {{a}} ÷ {{b}}?",
   "selectOperation": "Select Operation",
   "viewRecords": "View Records",
+  "viewMedals": "View Medals",
   "highScores": "High Scores",
-  "enterName": "Enter your name"
+  "enterName": "Enter your name",
+  "medalBoard": "Medal Board",
+  "gold": "Gold",
+  "silver": "Silver",
+  "bronze": "Bronze"
   ,"roundSummary": "Round Summary"
   ,"backToSelection": "Back to Selection"
   ,"currentScore": "Current score: {{score}} / {{total}}"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -30,8 +30,13 @@
   "operation_all": "Todas",
   "selectOperation": "Seleccionar operación",
   "viewRecords": "Ver récords",
+  "viewMedals": "Ver medallas",
   "highScores": "Récords",
-  "enterName": "Ingresa tu nombre"
+  "enterName": "Ingresa tu nombre",
+  "medalBoard": "Tabla de medallas",
+  "gold": "Oro",
+  "silver": "Plata",
+  "bronze": "Bronce"
   ,"roundSummary": "Resumen de ronda"
   ,"backToSelection": "Volver a selección"
   ,"currentScore": "Puntuación actual: {{score}} / {{total}}"

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import HomeScreen from '../components/HomeScreen';
 import SelectionScreen from '../components/SelectionScreen';
 import HighScoreScreen from '../components/HighScoreScreen';
+import MedalBoardScreen from '../components/MedalBoardScreen';
 import QuizScreen from '../components/QuizScreen';
 import ResultScreen from '../components/ResultScreen';
 import RoundSummaryScreen from '../components/RoundSummaryScreen';
@@ -21,6 +22,7 @@ export default function AppNavigator() {
         <Stack.Screen name="Selection" component={SelectionScreen} />
         <Stack.Screen name="Quiz" component={QuizScreen} />
         <Stack.Screen name="HighScore" component={HighScoreScreen} />
+        <Stack.Screen name="MedalBoard" component={MedalBoardScreen} />
         <Stack.Screen name="Result" component={ResultScreen} />
         <Stack.Screen name="RoundSummary" component={RoundSummaryScreen} />
       </Stack.Navigator>

--- a/src/storage/medalBoard.ts
+++ b/src/storage/medalBoard.ts
@@ -1,0 +1,69 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Operation, OperationRecord, BadgeLevel } from '../types/score';
+import type { MedalBoardMap, OperationCount } from '../types/score';
+
+const MEDAL_BOARD_KEY = 'MEDAL_BOARD';
+
+const DEFAULT_BOARD: MedalBoardMap = {
+  add: [],
+  subtract: [],
+  multiply: [],
+  divide: [],
+};
+
+export const getMedalBoard = async (): Promise<MedalBoardMap> => {
+  const value = await AsyncStorage.getItem(MEDAL_BOARD_KEY);
+  if (!value) {
+    return { ...DEFAULT_BOARD };
+  }
+  try {
+    const parsed = JSON.parse(value) as Partial<MedalBoardMap>;
+    const result: MedalBoardMap = { ...DEFAULT_BOARD };
+    (Object.keys(DEFAULT_BOARD) as Operation[]).forEach((op) => {
+      const arr = parsed[op];
+      result[op] = Array.isArray(arr) ? (arr as OperationRecord[]) : [];
+    });
+    return result;
+  } catch {
+    return { ...DEFAULT_BOARD };
+  }
+};
+
+export const setMedalBoard = async (
+  board: MedalBoardMap
+): Promise<void> => {
+  await AsyncStorage.setItem(MEDAL_BOARD_KEY, JSON.stringify(board));
+};
+
+export const updateMedalBoard = async (
+  scores: OperationCount,
+  totals: OperationCount,
+  playerName: string
+): Promise<void> => {
+  const board = await getMedalBoard();
+  let changed = false;
+  (Object.keys(scores) as Operation[]).forEach((op) => {
+    const score = scores[op];
+    if (score > 0) {
+      const total = totals[op];
+      const pct = total ? score / total : 0;
+      let badge: BadgeLevel = null;
+      if (pct === 1) badge = 'gold';
+      else if (pct >= 0.8) badge = 'silver';
+      else if (pct >= 0.5) badge = 'bronze';
+      const record: OperationRecord = {
+        score,
+        playerName,
+        date: new Date().toISOString(),
+        badge,
+      };
+      const arr = [...board[op], record];
+      arr.sort((a, b) => b.score - a.score);
+      board[op] = arr.slice(0, 3);
+      changed = true;
+    }
+  });
+  if (changed) {
+    await setMedalBoard(board);
+  }
+};

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -2,6 +2,7 @@ export type RootStackParamList = {
   Home: undefined;
   Selection: { playerName: string; score?: number };
   HighScore: undefined;
+  MedalBoard: undefined;
   Quiz: {
     operation?: import('./score').Operation | 'all';
     playerName: string;

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -12,3 +12,5 @@ export type OperationRecord = {
 };
 
 export type OperationRecordMap = Record<Operation, OperationRecord>;
+
+export type MedalBoardMap = Record<Operation, OperationRecord[]>;


### PR DESCRIPTION
## Summary
- new medal board storage module to keep top scores
- new MedalBoardScreen to display medal rankings
- track medal updates in quiz flow
- navigation/routes translations for new medal board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fb02bcbc832a9f31c4cff76b6aeb