### PR TITLE
Add medal summary counts

### DIFF
--- a/__tests__/HighScoreScreen.test.tsx
+++ b/__tests__/HighScoreScreen.test.tsx
@@ -23,6 +23,12 @@ jest.mock('../src/storage/highScore', () => ({
   ),
 }));
 
+jest.mock('../src/storage/medalBoard', () => ({
+  getMedalCounts: jest.fn(() =>
+    Promise.resolve({ gold: 1, silver: 1, bronze: 0, none: 38 })
+  ),
+}));
+
 describe('HighScoreScreen', () => {
   beforeEach(() => setLocale('en'));
 
@@ -34,5 +40,6 @@ describe('HighScoreScreen', () => {
     );
     await findByText(`${t('addition')}: 2 (Bob 2024-01-01) - Gold Badge`);
     await findByText(`${t('subtraction')}: 1 (Alice 2024-01-02) - Silver Badge`);
+    await findByText(t('medalSummary'));
   });
 });

--- a/src/components/HighScoreScreen.tsx
+++ b/src/components/HighScoreScreen.tsx
@@ -8,6 +8,7 @@ import { RootStackParamList } from '../types/navigation';
 import { getHighScore } from '../storage/highScore';
 import { t } from '../i18n';
 import type { OperationRecordMap, BadgeLevel } from '../types/score';
+import MedalSummary from './MedalSummary';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },
@@ -52,6 +53,7 @@ const HighScoreScreen: React.FC<Props> = ({ navigation }) => {
           </Text>
         </Card.Content>
       </Card>
+      <MedalSummary />
       <Button mode="contained" onPress={() => navigation.goBack()}>
         {t('goHome')}
       </Button>

--- a/src/components/MedalSummary.tsx
+++ b/src/components/MedalSummary.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import { t } from '../i18n';
+import { getMedalCounts } from '../storage/medalBoard';
+import type { MedalCounts } from '../types/score';
+
+const styles = StyleSheet.create({
+  container: { marginTop: 16 },
+  row: { flexDirection: 'row', justifyContent: 'space-around', marginTop: 4 },
+  total: { textAlign: 'center', marginTop: 4 },
+});
+
+const MedalSummary: React.FC = () => {
+  const [counts, setCounts] = useState<MedalCounts>({
+    gold: 0,
+    silver: 0,
+    bronze: 0,
+    none: 40,
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      getMedalCounts().then(setCounts);
+    }, [])
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text variant="titleMedium">{t('medalSummary')}</Text>
+      <View style={styles.row}>
+        <Text>🥇 {counts.gold}</Text>
+        <Text>🥈 {counts.silver}</Text>
+        <Text>🥉 {counts.bronze}</Text>
+        <Text>❌ {counts.none}</Text>
+      </View>
+      <Text style={styles.total}>40 {t('total')}</Text>
+    </View>
+  );
+};
+
+export default MedalSummary;

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -40,5 +40,7 @@
   ,"roundSummary": "Rundenübersicht"
   ,"backToSelection": "Zur Auswahl zurück"
   ,"currentScore": "Aktueller Punktestand: {{score}} / {{total}}"
+  ,"medalSummary": "Medaillenübersicht"
+  ,"total": "insgesamt"
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,5 +40,7 @@
   ,"roundSummary": "Round Summary"
   ,"backToSelection": "Back to Selection"
   ,"currentScore": "Current score: {{score}} / {{total}}"
+  ,"medalSummary": "Medal Summary"
+  ,"total": "total"
 }
 

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -40,5 +40,7 @@
   ,"roundSummary": "Resumen de ronda"
   ,"backToSelection": "Volver a selección"
   ,"currentScore": "Puntuación actual: {{score}} / {{total}}"
+  ,"medalSummary": "Resumen de medallas"
+  ,"total": "total"
 }
 

--- a/src/storage/medalBoard.ts
+++ b/src/storage/medalBoard.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Operation, OperationRecord, BadgeLevel } from '../types/score';
-import type { MedalBoardMap, OperationCount } from '../types/score';
+import type { MedalBoardMap, OperationCount, MedalCounts } from '../types/score';
 
 const MEDAL_BOARD_KEY = 'MEDAL_BOARD';
 
@@ -66,4 +66,21 @@ export const updateMedalBoard = async (
   if (changed) {
     await setMedalBoard(board);
   }
+};
+
+export const getMedalCounts = async (): Promise<MedalCounts> => {
+  const board = await getMedalBoard();
+  let gold = 0;
+  let silver = 0;
+  let bronze = 0;
+  (Object.keys(board) as Operation[]).forEach((op) => {
+    board[op].forEach((rec) => {
+      if (rec.badge === 'gold') gold += 1;
+      else if (rec.badge === 'silver') silver += 1;
+      else if (rec.badge === 'bronze') bronze += 1;
+    });
+  });
+  const total = 40;
+  const none = Math.max(0, total - gold - silver - bronze);
+  return { gold, silver, bronze, none };
 };

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -14,3 +14,10 @@ export type OperationRecord = {
 export type OperationRecordMap = Record<Operation, OperationRecord>;
 
 export type MedalBoardMap = Record<Operation, OperationRecord[]>;
+
+export type MedalCounts = {
+  gold: number;
+  silver: number;
+  bronze: number;
+  none: number;
+};


### PR DESCRIPTION
## Summary
- add `MedalCounts` type
- compute counts in `medalBoard` storage
- show summary on HighScore screen with new `MedalSummary` component
- localize text for medal summary
- test updated HighScore screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873fd45ad4c832a830cc236c97da945