### PR TITLE
Add medal count translations

### DIFF
--- a/src/components/MedalBoardScreen.tsx
+++ b/src/components/MedalBoardScreen.tsx
@@ -49,7 +49,7 @@ const MedalBoardScreen: React.FC<Props> = ({ navigation }) => {
     <SafeAreaView style={styles.container}>
       <Card style={styles.card} elevation={2}>
         <Card.Content>
-          <Text variant="titleLarge">{t('medalBoard')}</Text>
+          <Text variant="titleLarge">{t('medalBoardTitle')}</Text>
           {renderList('add', t('addition'))}
           {renderList('subtract', t('subtraction'))}
           {renderList('multiply', t('multiplication'))}

--- a/src/components/MedalSummary.tsx
+++ b/src/components/MedalSummary.tsx
@@ -30,10 +30,10 @@ const MedalSummary: React.FC = () => {
     <View style={styles.container}>
       <Text variant="titleMedium">{t('medalSummary')}</Text>
       <View style={styles.row}>
-        <Text>🥇 {counts.gold}</Text>
-        <Text>🥈 {counts.silver}</Text>
-        <Text>🥉 {counts.bronze}</Text>
-        <Text>❌ {counts.none}</Text>
+        <Text>{t('goldCount', { count: counts.gold })}</Text>
+        <Text>{t('silverCount', { count: counts.silver })}</Text>
+        <Text>{t('bronzeCount', { count: counts.bronze })}</Text>
+        <Text>{t('noBadgeCount', { count: counts.none })}</Text>
       </View>
       <Text style={styles.total}>40 {t('total')}</Text>
     </View>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -37,6 +37,11 @@
   "gold": "Gold",
   "silver": "Silber",
   "bronze": "Bronze"
+ ,"medalBoardTitle": "Medaillenrangliste"
+ ,"goldCount": "🥇 {{count}}"
+ ,"silverCount": "🥈 {{count}}"
+ ,"bronzeCount": "🥉 {{count}}"
+ ,"noBadgeCount": "❌ {{count}}"
   ,"roundSummary": "Rundenübersicht"
   ,"backToSelection": "Zur Auswahl zurück"
   ,"currentScore": "Aktueller Punktestand: {{score}} / {{total}}"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -37,6 +37,11 @@
   "gold": "Gold",
   "silver": "Silver",
   "bronze": "Bronze"
+ ,"medalBoardTitle": "Medal Board"
+ ,"goldCount": "🥇 {{count}}"
+ ,"silverCount": "🥈 {{count}}"
+ ,"bronzeCount": "🥉 {{count}}"
+ ,"noBadgeCount": "❌ {{count}}"
   ,"roundSummary": "Round Summary"
   ,"backToSelection": "Back to Selection"
   ,"currentScore": "Current score: {{score}} / {{total}}"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -37,6 +37,11 @@
   "gold": "Oro",
   "silver": "Plata",
   "bronze": "Bronce"
+ ,"medalBoardTitle": "Tabla de medallas"
+ ,"goldCount": "🥇 {{count}}"
+ ,"silverCount": "🥈 {{count}}"
+ ,"bronzeCount": "🥉 {{count}}"
+ ,"noBadgeCount": "❌ {{count}}"
   ,"roundSummary": "Resumen de ronda"
   ,"backToSelection": "Volver a selección"
   ,"currentScore": "Puntuación actual: {{score}} / {{total}}"


### PR DESCRIPTION
## Summary
- add medal count translations to i18n JSON files
- use new translation keys in MedalBoardScreen and MedalSummary

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873fedb9090832a8bb26315ba76081b