### PR TITLE
Improve medal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ This project is a simple quiz application built with [Expo](https://expo.dev) an
    ```
 3. The CLI will offer options to open the app in a development build, simulator/emulator or Expo Go.
 
+### Usage
+
+1. Launch the development server and open the app on a device or emulator.
+2. From the home screen enter your name and start a quiz.
+3. After each round you can review mistakes before moving on.
+4. Use the **View Records** and **View Medals** buttons on the selection screen to see stored high scores and medal standings.
+
 To run the Jest test suite use:
 ```bash
 npm test
@@ -29,6 +36,17 @@ npm test
 - Badge system that rewards bronze, silver or gold depending on the final score
 - Works on Android, iOS and the web via Expo
 - Multi-language UI with runtime language selection
+- Medal board stores the top three results per operation and tracks how many medals have been collected
+
+## Medal standings
+
+Medals are awarded for each arithmetic operation based on accuracy:
+
+- **Gold** – 100% correct answers
+- **Silver** – at least 80% correct
+- **Bronze** – at least 50% correct
+
+Whenever a quiz finishes, the `updateMedalBoard` function writes the result to `AsyncStorage`. Each operation keeps the best three scores along with the medal earned. A summary view counts all medals collected out of **40 total badges** available across the app.
 
 ## Animations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-This project is a small Expo/React Native application with three main screens managed by React Navigation. Component files live in `src/components` and the stack navigator is defined in `src/navigation/AppNavigator.tsx`.
+This project is a small Expo/React Native application with several screens managed by React Navigation. Component files live in `src/components` and the stack navigator is defined in `src/navigation/AppNavigator.tsx`.
 
 ## Main Components
 
@@ -8,14 +8,19 @@ This project is a small Expo/React Native application with three main screens ma
 - **QuizScreen** – Presents questions from `src/data/questions.ts`. Answers are evaluated immediately and incorrect answers are queued for a review round. When all questions (and reviews) are completed, the result screen is shown.
 - **ResultScreen** – Displays the final score and any earned badges. Provides a button to return to the Home screen.
 - **BadgeDisplay** – Renders a list of earned badge icons used on the result screen.
+- **HighScoreScreen** – Shows the best scores for each operation together with any medals earned.
+- **MedalBoardScreen** – Lists the top three records per operation and allows players to review medal standings.
+- **RoundSummaryScreen** – Appears when a cycle contains mistakes so users can review incorrect questions.
 
 ## Data Flow
 
 1. `HomeScreen` reads the stored high score using `getHighScore()` from `src/storage/highScore.ts`.
 2. When the user starts a quiz, `QuizScreen` iterates through the questions array. Correct answers increment the score, while incorrect answers are pushed onto a review queue.
 3. After answering all questions, any queued items are presented again in review mode until all are answered correctly.
-4. On completion, `QuizScreen` compares the score with the saved high score and writes a new high score using `setHighScore()` if needed. Then navigation transitions to `ResultScreen` with the final score as parameters.
-5. `ResultScreen` calculates earned badges based on the score percentage and renders them with `BadgeDisplay`. Pressing the button navigates back to `HomeScreen` where the updated high score is shown.
+4. On completion, `QuizScreen` compares the score with the saved high score and writes a new high score using `setHighScore()` if needed. Medal standings are updated through `updateMedalBoard()` which persists the result in `AsyncStorage`. Navigation then transitions to `ResultScreen` with the final score as parameters.
+5. `ResultScreen` calculates earned badges based on the score percentage and renders them with `BadgeDisplay`. Pressing the button navigates back to `HomeScreen` where the updated high score and medal summary are shown.
 
 This simple flow keeps all state within the currently displayed screen and stores only the persistent high score in `AsyncStorage`.
+
+The medal board uses the same storage mechanism. Each quiz completion may award a gold, silver or bronze medal for an operation. Records are sorted and only the best three per category are kept. The `getMedalCounts()` helper aggregates these records so the UI can display how many of the **40 possible badges** have been earned.
 


### PR DESCRIPTION
## Summary
- document usage, medal board and medal counts in README
- explain medal storage and counts in architecture docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740032a1f0832ab330913723caff0e