### PR TITLE
Add Jest dev dependency and test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ This project is a simple quiz application built with [Expo](https://expo.dev) an
 3. After each round you can review mistakes before moving on.
 4. Use the **View Records** and **View Medals** buttons on the selection screen to see stored high scores and medal standings.
 
-To run the Jest test suite use:
+## Running tests
+
+Install dependencies once with `npm install` and then execute:
+
 ```bash
 npm test
 ```
+
+This runs the Jest suite located in the `__tests__` folder.
 
 ## Features
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,11 @@
+# Running the test suite
+
+1. Install dependencies if you haven't already:
+   ```bash
+   npm install
+   ```
+2. Execute the tests using the `test` script:
+   ```bash
+   npm test
+   ```
+   This runs Jest using the configuration in `package.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
         "react-test-renderer": "19.0.0",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "react-test-renderer": "19.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0"
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
## Summary
- list `jest` as a dev dependency
- document how to run the tests
- add standalone testing guide

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687407446e2c832a8effbe8f98c963a9