### PR TITLE
Switch to lottie-react-native

### DIFF
--- a/__tests__/RoundSummaryScreen.test.tsx
+++ b/__tests__/RoundSummaryScreen.test.tsx
@@ -5,7 +5,7 @@ import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale, t } from '../src/i18n';
 import { generateQuestions } from '../src/data/questions';
 
-jest.mock('lottie-react', () => 'Lottie');
+jest.mock('lottie-react-native', () => 'LottieView');
 
 jest.mock('../src/storage/highScore', () => ({
   updateHighScoreIfNeeded: jest.fn(() => Promise.resolve()),

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "react-native-screens": "~4.11.1",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "lottie-react-native": "^6.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "lottie-react": "^2.3.2"
+    "lottie-react": "^2.3.2",
+    "lottie-react-native": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -9,7 +9,7 @@ import { updateMedalBoard } from '../storage/medalBoard';
 import type { MathQuestion } from '../data/questions';
 import { t, type TranslationKey } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
-import Lottie from 'lottie-react';
+import LottieView from 'lottie-react-native';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },
@@ -56,8 +56,8 @@ const RoundSummaryScreen: React.FC<Props> = ({ navigation, route }) => {
   return (
     <SafeAreaView style={styles.container}>
       {showAnimation && (
-        <Lottie
-          animationData={
+        <LottieView
+          source={
             allCorrect
               ? require('../../assets/lottie/success.json')
               : require('../../assets/lottie/failure.json')


### PR DESCRIPTION
## Summary
- add `lottie-react-native` dependency
- use `LottieView` component in `RoundSummaryScreen`
- update test mocks for new import

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx expo prebuild` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753055ad88832a832d2f04060ff344