### PR TITLE
Fix CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A&A Quiz App
 
-[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+[![CI](https://github.com/lopillo/A-A-Quiz-App/actions/workflows/ci.yml/badge.svg)](https://github.com/lopillo/A-A-Quiz-App/actions/workflows/ci.yml)
 
 This project is a simple quiz application built with [Expo](https://expo.dev) and React Native. It showcases a minimal navigation flow with a home screen, quiz questions and a results view that awards badges based on your score. Questions and high score data are stored locally so you can practise even without a network connection.
 


### PR DESCRIPTION
## Summary
- update README CI badge to reference `lopillo/A-A-Quiz-App`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753160acb8832abdb987789df207a7