### PR TITLE
Add LottieWrapper to support web animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Whenever a quiz finishes, the `updateMedalBoard` function writes the result to `
 ## Animations
 
 The celebratory animation on the result screen is powered by
-[Lottie](https://airbnb.io/lottie/) using the `lottie-react` package. Animation
-data lives in the `assets/lottie` folder where the `success.json` and
+[Lottie](https://airbnb.io/lottie/). A small `LottieWrapper` component selects
+`lottie-react-native` on mobile and `lottie-web` when running on the web.
+Animation data lives in the `assets/lottie` folder where the `success.json` and
 `failure.json` files reside.
 
 To use a different animation:
@@ -65,10 +66,9 @@ To use a different animation:
 1. Drop the new `.json` file into `assets/lottie`.
 2. Update the `require` statement in
    `src/components/RoundSummaryScreen.tsx` to point at your file.
-3. Rebuild the project. The library automatically uses `lottie-web` for web
-   builds and `lottie-react-native` on Android and iOS, so no extra setup is
-   required. Avoid animations that load external images as they may not render
-   consistently across platforms.
+3. Rebuild the project. `LottieWrapper` handles both environments so no extra
+   setup is required. Avoid animations that load external images as they may not
+   render consistently across platforms.
 
 ## Adding translations
 

--- a/__tests__/RoundSummaryScreen.test.tsx
+++ b/__tests__/RoundSummaryScreen.test.tsx
@@ -5,7 +5,7 @@ import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale, t } from '../src/i18n';
 import { generateQuestions } from '../src/data/questions';
 
-jest.mock('lottie-react-native', () => 'LottieView');
+jest.mock('../src/components/LottieWrapper', () => 'LottieView');
 
 jest.mock('../src/storage/highScore', () => ({
   updateHighScoreIfNeeded: jest.fn(() => Promise.resolve()),

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
-        "lottie-react-native": "^6.1.0"
+        "lottie-react-native": "^6.1.0",
+        "lottie-web": "^5.12.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "lottie-react": "^2.3.2",
-    "lottie-react-native": "^6.1.0"
+    "lottie-react-native": "^6.1.0",
+    "lottie-web": "^5.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/LottieWrapper.tsx
+++ b/src/components/LottieWrapper.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef } from 'react';
+import { Platform, View } from 'react-native';
+import LottieViewNative from 'lottie-react-native';
+import lottieWeb from 'lottie-web';
+
+const WebAnimation: React.FC<any> = ({ source, autoPlay = false, loop = false, style }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      const anim = lottieWeb.loadAnimation({
+        container: ref.current,
+        renderer: 'svg',
+        loop,
+        autoplay: autoPlay,
+        animationData: typeof source === 'string' ? undefined : source,
+        path: typeof source === 'string' ? source : undefined,
+      });
+      return () => anim.destroy();
+    }
+  }, [source, autoPlay, loop]);
+
+  return <View ref={ref as any} style={style} />;
+};
+
+const LottieWrapper: React.ComponentType<any> = Platform.select({
+  web: WebAnimation,
+  default: LottieViewNative,
+}) as React.ComponentType<any>;
+
+export default LottieWrapper;

--- a/src/components/RoundSummaryScreen.tsx
+++ b/src/components/RoundSummaryScreen.tsx
@@ -9,7 +9,7 @@ import { updateMedalBoard } from '../storage/medalBoard';
 import type { MathQuestion } from '../data/questions';
 import { t, type TranslationKey } from '../i18n';
 import { useLanguage } from '../i18n/LanguageContext';
-import LottieView from 'lottie-react-native';
+import LottieView from './LottieWrapper';
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 16 },


### PR DESCRIPTION
## Summary
- use a new `LottieWrapper` component to pick between `lottie-react-native` and `lottie-web`
- switch `RoundSummaryScreen` to use `LottieWrapper`
- update tests to mock `LottieWrapper`
- document the wrapper in README
- add `lottie-web` dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687538be4ecc832aa9ff25f11810be8e