### PR TITLE
Show success animation on perfect quiz

### DIFF
--- a/__tests__/ResultScreen.test.tsx
+++ b/__tests__/ResultScreen.test.tsx
@@ -6,6 +6,8 @@ import type { OperationCount } from '../src/types/score';
 import { LanguageProvider } from '../src/i18n/LanguageContext';
 import { setLocale } from '../src/i18n';
 
+jest.mock('../src/components/LottieWrapper', () => 'LottieView');
+
 const questions = generateQuestions();
 const TOTALS: OperationCount = questions.reduce<OperationCount>(
   (acc, q) => ({ ...acc, [q.operation]: acc[q.operation] + 1 }),
@@ -59,5 +61,10 @@ describe('ResultScreen badges', () => {
     const scores = { add: 0, subtract: 0, multiply: 0, divide: 0 };
     const { queryByText } = renderScreen(scores, TOTALS);
     expect(queryByText('Badges Earned:')).toBeNull();
+  });
+
+  it('renders success animation on a perfect score', () => {
+    const { UNSAFE_getByType } = renderScreen(PERFECT, TOTALS);
+    expect(UNSAFE_getByType('LottieView')).toBeTruthy();
   });
 });

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Text } from 'react-native-paper';
 import { StyleSheet } from 'react-native';
 import BadgeDisplay, { Badge } from './BadgeDisplay';
+import LottieWrapper from './LottieWrapper';
 import { RootStackParamList } from '../types/navigation';
 import type { Operation, OperationCount } from '../types/score';
 import { t } from '../i18n';
@@ -50,8 +51,19 @@ export default function ResultScreen({ navigation, route }: Props) {
 
   const badges = getEarnedBadges();
 
+  const perfectRun = (Object.keys(totals) as Operation[]).every(
+    (op) => scores[op] === totals[op]
+  );
+
   return (
     <SafeAreaView style={styles.container}>
+      {perfectRun && (
+        <LottieWrapper
+          source={require('../../assets/lottie/success.json')}
+          autoPlay
+          loop={false}
+        />
+      )}
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleMedium">


### PR DESCRIPTION
## Summary
- import `LottieWrapper` in the result screen
- detect perfect runs and play success animation
- test that animation renders when a perfect score is achieved

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68756e96b80c832a9a80119ef8eff7d8