### PR TITLE
Add progress indicator

### DIFF
--- a/__tests__/QuizScreen.test.tsx
+++ b/__tests__/QuizScreen.test.tsx
@@ -91,4 +91,18 @@ describe('QuizScreen', () => {
       })
     );
   });
+
+  it('shows progress for the current cycle', () => {
+    const { getByText, getByTestId } = render(
+      <LanguageProvider>
+        <QuizScreen navigation={{} as any} route={{ key: '3', name: 'Quiz', params: { playerName: 'Bob' } } as any} />
+      </LanguageProvider>
+    );
+
+    const progressBar = getByTestId('progressBar');
+    expect(progressBar.props.progress).toBe(0);
+
+    fireEvent.press(getByText(questions[0].options[questions[0].correctAnswer]));
+    expect(getByTestId('progressBar').props.progress).toBeCloseTo(0.1);
+  });
 });

--- a/src/components/QuizScreen.tsx
+++ b/src/components/QuizScreen.tsx
@@ -2,7 +2,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Card, Text } from 'react-native-paper';
+import { Button, Card, Text, ProgressBar } from 'react-native-paper';
 import { updateHighScoreIfNeeded } from '../storage/highScore';
 import { updateMedalBoard } from '../storage/medalBoard';
 import { RootStackParamList } from '../types/navigation';
@@ -134,6 +134,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
 
   const questionIndexToShow = cycle * QUESTIONS_PER_CYCLE + current;
   const question = activeQuestions[questionIndexToShow];
+  const progress = current / QUESTIONS_PER_CYCLE;
 
   return (
     <SafeAreaView style={styles.container}>
@@ -148,6 +149,7 @@ const QuizScreen = ({ navigation, route }: Props) => {
           <Text style={styles.feedbackText}>{feedback === 'correct' ? '✓' : '✕'}</Text>
         </View>
       )}
+      <ProgressBar progress={progress} style={styles.progressBar} testID="progressBar" />
       <Card style={styles.card} elevation={2}>
         <Card.Content>
           <Text variant="titleLarge" style={styles.question}>
@@ -185,6 +187,9 @@ const styles = StyleSheet.create({
   },
   option: {
     marginVertical: 4,
+  },
+  progressBar: {
+    marginBottom: 12,
   },
   feedbackContainer: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- show per-round progress bar above quiz questions
- test cycle progress indicator

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687571f14778832a9aad1eac9175f765